### PR TITLE
GH-5: Align design docs to agentic design patterns

### DIFF
--- a/docs/ARCHITECTURE.yaml
+++ b/docs/ARCHITECTURE.yaml
@@ -3,125 +3,192 @@ title: Press Architecture
 
 overview:
   summary: |
-    We implement a runtime architecture where model-proposed tool calls are converted into
-    validated, permission-aware execution events persisted as crumbs in trail scope.
+    We implement a declarative agent runtime where the agent is a dataset the Engine
+    interprets. A Machine defines states, signals, and transitions as a YAML
+    transition table. The Engine is a fixed dispatch loop that consults the Machine,
+    resolves tools through the Registry, calls Execute, records the result as a crumb,
+    and routes the returned signal to the next transition. One binary interprets any
+    agent whose YAML conforms to the schema.
 
-    This runtime is a Go library invoked by the cobbler-scaffold orchestrator. It receives
-    a specification and produces code in the target language selected by the orchestrator.
-    The agent is language-agnostic: the orchestrator provides the target language, language-
-    specific rules, and build commands at invocation time. There is no interactive user
-    session. The loop starts when the orchestrator delivers a specification and ends when
-    code is produced or the agent reports a blocker. The orchestrator sets the system prompt,
-    provider configuration, language context, and workspace path before invocation.
+    This runtime is a Go library invoked by the cobbler-scaffold orchestrator. It
+    receives a specification and produces code in the target language selected by the
+    orchestrator. The agent is language-agnostic: the orchestrator provides the
+    target language, language-specific rules, and build commands at invocation time.
+    There is no interactive user session. The loop starts when the orchestrator
+    delivers a specification and ends when the Machine reaches a terminal state.
+    The orchestrator sets the system prompt, provider configuration, language
+    context, and workspace path before invocation.
 
-    The orchestrator creates an assignment crumb in its own workflow trail, then calls
-    invoke. The agent creates a loop trail with a branches_from link to the assignment
-    crumb, starts the loop in its own goroutine, and returns the loop trail ID immediately.
-    The orchestrator does not block. It discovers progress and outcome by querying the
-    loop trail state and crumbs via the cupboard.
+    The orchestrator creates an assignment crumb in its own workflow trail, then
+    calls invoke. The agent creates an execution trail with a branches_from link to
+    the assignment crumb, loads the Machine and tool declarations, validates them
+    against each other, and enters the dispatch loop. invoke returns the execution
+    trail ID immediately. The orchestrator does not block. It discovers progress and
+    outcome by querying the execution trail state and crumbs via the cupboard.
 
-    Conversation history is a trail-backed linked list of messages. Each message (system,
-    user, assistant, tool) is a crumb in the loop trail. The full message list is
-    sent to the LLM on every turn. Token usage is tracked in a stash scoped_to the loop
-    trail. If the context budget is exceeded, the loop terminates and the orchestrator
-    decides what to do (break down the specification, retry, or give up).
+    Conversation history is a trail-backed linked list of messages. Each message
+    (system, user, assistant, tool) is a crumb in the execution trail. The full
+    message list is sent to the LLM on every turn. Token usage is tracked in a stash
+    scoped_to the execution trail. If the context budget is exceeded, the Machine
+    routes to a Failed terminal state and the orchestrator decides what to do.
 
+    invoke_llm is a boundary tool declared in the Machine with its signal set
+    (LLMResponded, BudgetExceeded). The Model Adapter hides provider-specific wire
+    formats and returns pre-parsed ToolCallIntent objects with valid JSON arguments.
     LLM providers are Ollama (local) or AWS Bedrock (cloud). Provider selection and
-    credentials are configured in configuration.yaml. The LLM adapter hides provider
-    differences and returns pre-parsed ToolCallIntent objects with valid JSON arguments.
+    credentials are configured in configuration.yaml.
 
-    The orchestrator owns multi-agent coordination and routing, environment preparation
-    and workspace initialization, tool configuration and allowlist provisioning, git
-    branch and commit lifecycle, pull request and merge workflows, and cross-agent
-    dependency scheduling. The stitch runtime owns trail and crumb execution state,
-    tool invocation and validation pipeline, specification-to-code generation actions,
-    and execution outcome reporting.
+    The orchestrator owns multi-agent coordination and routing, environment
+    preparation and workspace initialization, tool configuration and allowlist
+    provisioning, git branch and commit lifecycle, pull request and merge workflows,
+    and cross-agent dependency scheduling. The runtime owns Machine interpretation,
+    tool dispatch, signal routing, execution recording, and rollback.
 
-    The runtime uses hexagonal dependency inversion. Core domain services
-    (AgentLoopOrchestrator, TrailManager, InvocationValidator, ModelResponseRouter,
-    UndoManager) depend on inbound ports (AgentInvokePort) and outbound ports
-    (LLMInvocationPort, WorkspaceDiscoveryReadPort, WorkspaceMutationPort,
-    ValidationPort, StateAuditPorts). Driving adapters (StitchBoundaryAdapter) and
-    driven adapters (LLMToolAdapter, WorkspaceDiscoveryAdapter, WorkspaceMutationAdapter,
-    ValidationAdapter, StateAuditAdapter) implement port contracts. Any adapter can be
-    swapped if it conforms to the bound port contract.
+    The runtime uses hexagonal dependency inversion. The Engine depends on outbound
+    ports (LLMInvocationPort, WorkspaceDiscoveryReadPort, WorkspaceMutationPort,
+    ValidationPort, StateAuditPorts, TracePort). Driven adapters (LLMToolAdapter,
+    WorkspaceDiscoveryAdapter, WorkspaceMutationAdapter, ValidationAdapter,
+    StateAuditAdapter, TraceAdapter) implement port contracts. The driving adapter
+    (StitchBoundaryAdapter) accepts orchestrator assignments and starts the Engine.
+    Any adapter can be swapped if it conforms to the bound port contract.
 
-    Observability uses standard Go log/slog. The cobbler orchestrator reads logs from
-    shared infrastructure. Future migration to OpenTelemetry is supported by the
-    structured logging approach.
+    Observability uses OpenTelemetry spans per tool execution and Machine transition,
+    with structured logging via Go log/slog as a fallback. The Trace Instrumentation
+    pattern gives per-step observability without modifying the Machine or tools.
   lifecycle: |
-    Trail lifecycle: draft -> active -> completed or abandoned.
+    Machine lifecycle: load -> validate -> run -> terminal.
 
-    Agentic loop lifecycle: receive prompt -> map to trail -> invoke llm.generate as standard tool ->
-    LLM object parses provider response and returns ToolCallIntent objects with parsed JSON arguments ->
-    classify output (terminal vs actionable) -> insert crumb or build next ToolCall from ToolCallIntent ->
-    repeat until terminal response.
+    Execution lifecycle: load Machine and tool declarations -> validate Machine
+    against tool signal sets -> enter initial state -> dispatch cycle (look up
+    (state, signal) in Machine, resolve tool through Registry, call Execute, record
+    crumb, route returned signal) -> repeat until terminal state.
 
-    Invocation lifecycle: received -> availability checked -> decoded (ToolCallIntent.arguments already
-    valid JSON from LLM boundary) -> semantically validated -> invoked or rejected -> persisted.
+    Tool lifecycle: registry resolves tool name -> factory constructs tool instance
+    -> Execute performs operation and returns signal -> crumb records result ->
+    Undo reverses operation when rollback is requested.
 
-    Undo lifecycle: plan built in reverse order -> steps executed -> undo crumbs persisted ->
-    summary produced.
+    Rollback lifecycle: Engine walks execution backward -> calls Undo on each tool
+    with recorded result -> undo crumbs persisted -> summary produced.
   coordination_pattern: |
-    The model proposes actions, and the runtime decides what can execute. Runtime components own
-    eligibility checks, validation ordering, execution boundaries, event emission, and persistence.
+    The Engine interprets the Machine. The Machine declares which tools can run in
+    which states. Tools return typed signals. The Engine routes signals to
+    transitions. No participant knows the others' internals.
 
-    The external orchestrator owns multi-agent assignment, agent selection, git management,
-    branch lifecycle, and merge orchestration.
+    The external orchestrator owns multi-agent assignment, agent selection, git
+    management, branch lifecycle, and merge orchestration.
 
-    Inbound flow: StitchBoundaryAdapter -> AgentInvokePort -> AgentLoopOrchestrator.
-    Outbound bindings: AgentLoopOrchestrator -> LLMInvocationPort -> LLMToolAdapter,
-    AgentLoopOrchestrator -> WorkspaceDiscoveryReadPort -> WorkspaceDiscoveryAdapter,
-    AgentLoopOrchestrator -> WorkspaceMutationPort -> WorkspaceMutationAdapter,
-    AgentLoopOrchestrator -> ValidationPort -> ValidationAdapter,
-    AgentLoopOrchestrator -> StateAuditPorts -> StateAuditAdapter.
+    Inbound flow: StitchBoundaryAdapter -> Engine.Run(machine, registry).
+    Outbound bindings: Engine -> LLMInvocationPort -> LLMToolAdapter,
+    Engine -> WorkspaceDiscoveryReadPort -> WorkspaceDiscoveryAdapter,
+    Engine -> WorkspaceMutationPort -> WorkspaceMutationAdapter,
+    Engine -> ValidationPort -> ValidationAdapter,
+    Engine -> StateAuditPorts -> StateAuditAdapter,
+    Engine -> TracePort -> TraceAdapter.
 
 interfaces:
   - name: Orchestrator Boundary
     summary: |
-      Contracts between the external orchestrator and the stitch runtime.
+      Contracts between the external orchestrator and the runtime Engine.
     data_structures:
       - "OrchestratorAssignment: assignment_id, trail_id, specification references, workspace path, execution budget"
-      - "AgentInvokeRequest: prompt, assignment_id, trail_id, invocation metadata"
-      - "AgentInvokeResponse: status, terminal_output, execution summary"
+      - "AgentInvokeRequest: prompt, assignment_id, trail_id, machine reference, tool declaration roots, invocation metadata"
+      - "AgentInvokeResponse: status, terminal_output, execution summary, outcome classification"
     operations:
-      - Accept orchestrator assignment envelope and initialize stitch execution context.
-      - Invoke agent with prompt as primary entrypoint.
-      - Return stitch execution result envelope to orchestrator.
-  - name: Trail and Stash
+      - Accept orchestrator assignment envelope and initialize execution context.
+      - Load Machine and tool declarations, validate against each other.
+      - Enter the dispatch loop and return execution trail ID.
+      - Return execution result envelope to orchestrator on terminal state.
+  - name: Machine and Registry
     summary: |
-      Contracts for trail lifecycle and stash-scoped tool availability.
+      Contracts for Machine data structure and Registry tool resolution.
     data_structures:
-      - "Trail: trail_id, state, active stash id, stash version"
-      - "Stash: stash_id, version, per-tool entries"
-      - "PromptReference: stash key or inline attachment metadata"
+      - "Machine: name, initial_state, terminal_states, transitions (state, signal, next_state, action)"
+      - "Signal: typed tool outcome used as transition lookup key"
+      - "Transition: state, signal, next_state, action (tool name or $tool for dynamic dispatch)"
+      - "Registry: map of tool name to tool implementation"
+      - "ToolDeclaration: name, type, parameters, emits, contract, reversibility, side_effects"
     operations:
-      - Resolve active stash for trail.
-      - Evaluate tool eligibility from stash.
-  - name: Tool Invocation
+      - "Resolve tool name to implementation through Registry."
+      - "Validate Machine: every state-signal pair exists, every tool name resolves, every signal a tool emits is handled."
+      - "Look up transition for (current_state, last_signal)."
+  - name: Tool Contract
     summary: |
-      Contracts for tool call normalization, validation, and execution.
+      Contracts for tool declaration, execution, and undo.
     data_structures:
-      - "ToolDescriptor: invocation metadata and undo mode"
-      - "ToolCallIntent: id, name, arguments (parsed JSON object), optional parse_error"
-      - "ToolCall: call_id, trail_id, tool_name, typed args (decoded from ToolCallIntent.arguments)"
-      - "Crumb: validation, execution, and rollback outcome metadata"
+      - "ToolContract: parameter types, emittable signals, undo mode, side effects"
+      - "ToolResult: signal, output, undo metadata"
+      - "Crumb: state, signal, tool, result metadata, undo metadata"
     operations:
-      - Decode raw args to typed Go structs.
-      - Validate tool semantics.
-      - Compose LLM prompt from crumb context and stash prompt references.
-      - Invoke tool and capture runtime and OS failures.
-      - Invoke LLM providers asynchronously with timeout and structured failures.
-      - Persist invocation crumb and optional undo metadata.
-      - Build and execute reverse-order undo plan.
-      - "Events: stitch_assignment_received, tool_call_received, tool_availability_rejected, tool_validation_rejected, tool_invocation_succeeded, tool_invocation_failed, stitch_result_emitted, undo_step_succeeded, undo_step_failed"
+      - Execute tool with typed parameters and return typed signal.
+      - Undo tool with recorded result (no-op for read-only tools).
+      - Declare signal set for static Machine validation.
+      - "Events: machine_loaded, machine_validated, tool_dispatched, tool_succeeded, tool_failed, signal_routed, terminal_state_reached, undo_step_succeeded, undo_step_failed"
 
 components:
+  - name: Engine
+    provided_by: runtime/core
+    responsibility: Interpret the Machine. Run the dispatch loop, resolve tools through the Registry, record crumbs, and route signals to transitions.
+    capabilities:
+      - load and validate Machine against tool signal sets
+      - "dispatch cycle: look up transition, resolve tool, call Execute, record crumb, route signal"
+      - "rollback: walk execution backward, call Undo per tool"
+      - resume from persisted checkpoint
+      - classify outcome (Clean, Recovery, Stuck, Divergent) on terminal state
+    references:
+      - prd001-tool-system-components-interfaces
+      - prd002-trail-lifecycle-state-machine
+
+  - name: Machine
+    provided_by: runtime/data
+    responsibility: |
+      Pure data structure mapping (state, signal) to (next_state, action). No logic,
+      conditionals, or loops. States are inert markers of position. Signals are typed
+      tool outcomes. Transitions route signals to the next state and tool. Terminal
+      states halt execution.
+    capabilities:
+      - declare states, signals, and transitions as YAML
+      - declare initial state and terminal states
+      - declare $tool slots for dynamic dispatch (model-selected tools)
+      - support per-state tool scoping
+    references:
+      - prd002-trail-lifecycle-state-machine
+
+  - name: Registry
+    provided_by: runtime/tools
+    responsibility: |
+      Resolve tool names to implementations at load time. Hold tool declarations
+      (parameter types, signal sets, undo modes, side effects). Validate that every
+      tool name referenced in the Machine has a declaration and every emittable
+      signal is handled by the Machine.
+    capabilities:
+      - tool declaration loading and schema validation
+      - tool name to implementation resolution
+      - factory dispatch for tool construction (exec, rest, builtin, boundary)
+      - signal set registration for static Machine validation
+    references:
+      - prd001-tool-system-components-interfaces
+      - prd004-tool-invocation-validation
+
+  - name: ToolContractValidator
+    provided_by: runtime/invocation
+    responsibility: |
+      Validate tool declarations against the Machine at load time. Check that every
+      tool referenced in the Machine has a declaration, every emittable signal is
+      handled in every state where the tool can be dispatched, and parameter types
+      match tool descriptors.
+    capabilities:
+      - static signal completeness checking
+      - tool name resolution verification
+      - parameter type matching
+      - undo mode declaration enforcement
+    references:
+      - prd004-tool-invocation-validation
+
   - name: TrailManager
     provided_by: runtime/core
-    responsibility: Own trail lifecycle and stash binding.
+    responsibility: Own execution trail lifecycle and stash binding.
     capabilities:
-      - create and activate trail
+      - create and activate execution trail
       - complete and abandon transitions
       - enforce terminal-state restrictions
     references:
@@ -129,109 +196,44 @@ components:
 
   - name: StitchBoundaryAdapter
     provided_by: runtime/integration
-    responsibility: Translate orchestrator assignment envelopes to internal execution context and return stitch results.
+    responsibility: |
+      Translate orchestrator assignment envelopes to internal execution context.
+      Load Machine and tool declarations, start the Engine, and return execution
+      results.
     capabilities:
       - assignment envelope validation
-      - runtime context initialization
-      - stitch result packaging
+      - runtime context initialization (machine, registry, provider config)
+      - stitch result packaging with outcome classification
     references:
-      - specs/use-cases/uc002-orchestrator-stitch-boundary.yaml
-
-  - name: AgentLoopOrchestrator
-    provided_by: runtime/core
-    responsibility: Drive loop turns from prompt receipt through response routing.
-    capabilities:
-      - prompt to trail mapping
-      - llm.generate loop-turn invocation
-      - loop continuation and completion control
-    references:
-      - prd002-trail-lifecycle-state-machine
-      - prd004-tool-invocation-validation
-
-  - name: StashManager
-    provided_by: runtime/stash
-    responsibility: Resolve and evaluate trail-scoped tool availability.
-    capabilities:
-      - stash lookup and version resolution
-      - per-tool eligibility decisions
-      - policy override exposure
-    references:
-      - prd003-tool-stash-availability
-
-  - name: ToolRegistry
-    provided_by: runtime/tools
-    responsibility: Provide canonical tool descriptors and adapter bindings.
-    capabilities:
-      - descriptor lookup
-      - undo mode lookup
-      - tool adapter resolution
-    references:
-      - prd001-tool-system-components-interfaces
+      - specs/use-cases/rel01.0-uc002-orchestrator-stitch-boundary.yaml
 
   - name: LLMToolAdapter
     provided_by: runtime/tools
     responsibility: |
-      Build prompts and invoke configured LLM providers with instrumentation.
-      Hide all provider-specific wire formats and return ToolCallIntent objects
-      with syntactically valid JSON arguments (Ollama-style boundary).
+      Implement the invoke_llm boundary tool. Build prompts from stash references
+      and crumb context. Invoke configured LLM providers with instrumentation. Hide
+      all provider-specific wire formats and return ToolCallIntent objects with
+      syntactically valid JSON arguments. Emit LLMResponded or BudgetExceeded
+      signals.
     capabilities:
       - prompt composition from stash references and crumb attachments
-      - asynchronous provider invocation
+      - asynchronous provider invocation with timeout
       - provider-native response parsing into ToolCallIntent objects
       - syntactic JSON validation of tool call arguments before return
-      - timeout and failure normalization
+      - signal emission (LLMResponded, BudgetExceeded)
       - per-provider instrumentation and metrics
     references:
-      - prd001-tool-system-components-interfaces
-      - prd004-tool-invocation-validation
-
-  - name: ToolCallInterpreter
-    provided_by: runtime/invocation
-    responsibility: Normalize model and parser outputs into canonical ToolCall.
-    capabilities:
-      - native tool call adaptation
-      - parser output adaptation
-      - call correlation id assignment
-    references:
-      - prd004-tool-invocation-validation
-
-  - name: ModelResponseRouter
-    provided_by: runtime/core
-    responsibility: Route LLM outputs to crumb insertion or next invocation.
-    capabilities:
-      - classify terminal vs actionable outputs
-      - write output-only crumb path
-      - dispatch next invocation path
-    references:
-      - prd001-tool-system-components-interfaces
-      - prd004-tool-invocation-validation
-
-  - name: InvocationValidator
-    provided_by: runtime/invocation
-    responsibility: Enforce decode and semantic validation sequence.
-    capabilities:
-      - typed decode for JSON and YAML
-      - semantic validator dispatch
-      - stage-specific rejection reasons
-    references:
-      - prd004-tool-invocation-validation
-
-  - name: PermissionExecutor
-    provided_by: runtime/execution
-    responsibility: Execute validated calls and map runtime failures.
-    capabilities:
-      - execute-and-report baseline policy
-      - timeout and cancellation controls
-      - structured OS failure mapping
-    references:
+      - prd006-stitch-essential-toolset
       - prd004-tool-invocation-validation
 
   - name: CrumbLedger
     provided_by: runtime/ledger
-    responsibility: Persist invocation and undo outcomes as crumbs.
+    responsibility: |
+      Persist execution and undo outcomes as crumbs. Each dispatch cycle records
+      state, signal, tool, and result metadata. Undo crumbs link to original crumbs.
     capabilities:
-      - primary invocation crumb writes
-      - rejection crumb writes
+      - execution crumb writes per dispatch cycle
+      - rejection crumb writes for validation failures
       - undo crumb linkage to original crumbs
     references:
       - prd001-tool-system-components-interfaces
@@ -239,269 +241,279 @@ components:
 
   - name: UndoManager
     provided_by: runtime/undo
-    responsibility: Build and execute compensation and rollback plans.
+    responsibility: |
+      Walk execution backward via recorded crumbs, calling each tool's Undo method
+      with its recorded result. Report success, failure, skipped, and non-reversible
+      counts.
     capabilities:
-      - reverse-order undo planning
-      - mode-aware undo execution
+      - reverse-order undo execution via Engine
+      - per-tool Undo dispatch with recorded result
       - unresolved side-effect reporting
     references:
       - prd005-undo-and-compensation
 
+  - name: TraceAdapter
+    provided_by: runtime/observability
+    responsibility: |
+      Emit OpenTelemetry spans per tool execution and Machine transition. Provide
+      per-step observability without modifying the Machine or tools. Structured
+      logging via Go log/slog as fallback.
+    capabilities:
+      - OpenTelemetry span emission per dispatch cycle
+      - span correlation by trail id and execution id
+      - structured logging fallback via log/slog
+    references:
+      - prd027-trace-instrumentation
+
 design_decisions:
   - id: 1
-    title: Trail-scoped stash binding
-    decision: We bind each active trail to one stash version as the eligibility authority.
+    title: Machine as data, not code
+    decision: |
+      The agent's control flow is a YAML transition table, not imperative code.
+      States, signals, and transitions are data the Engine interprets. The Machine
+      has no logic, conditionals, or loops. This is the State Interpreter pattern.
     benefits:
-      - deterministic capability checks
-      - auditable policy scope
+      - static validation before execution — every state-signal pair exists, every
+        tool name resolves, every signal is handled
+      - auditable execution — the transition table is a reviewable artifact
+      - diffability — agent changes are YAML diffs, not code edits
+      - one binary interprets any agent whose YAML conforms to the schema
     alternatives_rejected:
-      - global allowlist with per-call exceptions
+      - imperative AgentLoopOrchestrator with if/elif branches (control flow buried
+        in code, not reviewable)
+      - LangGraph-style code conditions (cannot be statically validated without
+        execution)
 
   - id: 2
-    title: Typed decode before semantic validation
-    decision: We decode call args into typed Go structs before semantic checks.
+    title: Declarative Agent — three YAML layers
+    decision: |
+      The complete agent definition is three data files interpreted by a fixed
+      binary: Machine (transition table), Tool declarations (parameter types,
+      signals, undo modes), and Profile (model binding, budget, tool roots). This
+      is the Declarative Agent pattern.
     benefits:
-      - early structural failure detection
-      - clearer validation errors
+      - agent is a dataset, not a program — reviewable, versionable, swappable
+      - model swapping is a one-field edit in the Profile
+      - pre-deployment validation catches wiring errors before execution
+      - multiple agents run from one binary
     alternatives_rejected:
-      - schema-free map-only validation
+      - agent behaviour scattered across code, config, and deployment scripts
+      - separate binary per agent
 
   - id: 3
-    title: Execute-and-report baseline permission behavior
-    decision: We invoke and report exact runtime and OS failures as structured outcomes.
+    title: Typed signals with closed-world assumption
+    decision: |
+      Every tool declares a finite set of signals it can emit. The Machine must
+      handle every possible signal. An unhandled signal is a static load-time error,
+      caught before execution begins. This is the Tool Contract pattern.
     benefits:
-      - simpler initial runtime behavior
-      - no synthetic success semantics
+      - no ad hoc classification in Engine code — the Machine routes signals
+      - static validation catches wiring errors before any tool runs
+      - tools are opaque to the Machine — only name and signal set matter
     alternatives_rejected:
-      - mandatory preflight policy engine in first release
+      - untyped tool outcomes with runtime classification (ModelResponseRouter ad
+        hoc terminal vs actionable)
+      - open signal sets (no static validation possible)
 
   - id: 4
-    title: Explicit undo mode declaration
-    decision: Each tool descriptor must declare undo mode.
+    title: Per-state tool scoping
+    decision: |
+      Tool availability is driven by Machine state. The Machine declares which tools
+      can run in which states. Tools not declared for the current state cannot
+      execute. This is the Scoped Toolset pattern. The stash concept survives as the
+      mechanism for per-state tool scoping.
     benefits:
-      - realistic rollback guarantees
-      - explicit non-reversible behavior handling
+      - workflow invariants enforced by the Machine, not runtime checks
+      - deny-by-default — tools not in the current state's scope are rejected
+      - auditable tool availability per state
     alternatives_rejected:
-      - implicit rollback assumptions for all tools
+      - trail-scoped stash with no per-state granularity (coarser, allows tools
+        outside their intended state)
+      - global allowlist with per-call exceptions
 
   - id: 5
-    title: LLM-as-tool loop execution
-    decision: We register llm.generate as a tool and run it through the same invocation pipeline as all tools.
+    title: invoke_llm as boundary tool
+    decision: |
+      invoke_llm is a boundary tool declared in the Machine with its signal set
+      (LLMResponded, BudgetExceeded). The Engine dispatches it like any other tool.
+      The Model Adapter hides provider differences. This is the Model Adapter
+      pattern.
     benefits:
-      - one control path for validation, execution, and audit
+      - one dispatch path for all tools, including the LLM
       - consistent crumb semantics for model and non-model calls
+      - provider differences invisible to the Engine
+      - model swapping is a Profile edit, not a code change
     alternatives_rejected:
-      - special-case model branch outside tool runtime
+      - special-cased LLM branch outside the tool dispatch cycle
+      - provider-specific logic in the Engine
 
   - id: 6
-    title: Barebones first with configured tools
-    decision: We ship a minimal runtime with configured tools and defer MCP and subagent orchestration.
+    title: Per-tool Undo with Engine-driven rollback
+    decision: |
+      Each tool implements Execute and Undo. The Engine walks execution backward via
+      recorded crumbs, calling each tool's Undo with its recorded result. Read-only
+      tools make Undo a no-op. Undo mode (none, reversible, compensating, snapshot)
+      is declared in the tool contract. This is the Execution Rollback pattern.
     benefits:
-      - smaller operational surface
-      - faster implementation and validation
+      - realistic rollback — each tool defines what undoing means
+      - machine-level execution recording gives the Engine the ordered crumb list
+      - non-reversible tools are explicit, not assumed
     alternatives_rejected:
-      - full parity with existing open-source agent ecosystems in first release
+      - implicit rollback assumptions for all tools
+      - UndoManager separate from Engine dispatch (rollback is an Engine operation)
 
   - id: 7
-    title: Prompt references are stash and crumb data
-    decision: Prompt templates and fragments are selected via stash configuration and attached or referenced in crumbs.
+    title: Hexagonal dependency inversion
+    decision: |
+      The Engine depends on outbound ports (LLMInvocationPort,
+      WorkspaceDiscoveryReadPort, WorkspaceMutationPort, ValidationPort,
+      StateAuditPorts, TracePort). Driven adapters implement port contracts. The
+      driving adapter (StitchBoundaryAdapter) accepts orchestrator assignments.
     benefits:
-      - deterministic prompt provenance per loop turn
-      - trail-specific prompt behavior without global prompt library coupling
+      - lower coupling between Engine and infrastructure
+      - adapter replacement without Engine rewrites
+      - testable Engine with mock adapters
     alternatives_rejected:
-      - implicit global prompt library for all calls
+      - direct Engine dependency on provider and filesystem implementations
 
   - id: 8
-    title: Async LLM invocation without mandatory proxy
-    decision: LLMToolAdapter uses provider SDKs directly and supports async execution, timeouts, and failure handling.
-    benefits:
-      - simple deployment path
-      - preserves future option to add proxy later
-    alternatives_rejected:
-      - mandatory proxy service in initial architecture
-
-  - id: 12
-    title: Ollama-style LLM boundary with pre-parsed tool calls
+    title: OpenTelemetry trace instrumentation
     decision: |
-      The LLM object hides all provider-specific response mapping and returns
-      ToolCallIntent objects with syntactically valid JSON arguments. Like the
-      Ollama chat API, the caller never sees raw provider wire formats. The
-      LLMToolAdapter owns per-provider parsing (OpenAI function_call, Anthropic
-      tool_use, Ollama tool_calls) and guarantees that arguments leaving the
-      LLM boundary are well-formed JSON/YAML objects, not raw strings.
+      Observability uses OpenTelemetry spans per tool execution and Machine
+      transition. The TraceAdapter emits spans correlated by trail id and execution
+      id. Structured logging via log/slog is the fallback. This is the Trace
+      Instrumentation pattern.
     benefits:
-      - downstream components never re-parse raw JSON strings
-      - malformed-output errors are caught at the source
-      - provider differences are invisible to the agentic loop
-      - consistent with Ollama API contract where tool_calls.function.arguments is already a parsed object
+      - per-step observability without modifying the Machine or tools
+      - span correlation gives end-to-end execution traces
+      - compatible with existing observability infrastructure
     alternatives_rejected:
-      - pass raw arguments as strings and defer parsing to ToolCallInterpreter
-      - require downstream tools to handle provider-specific formats
+      - log/slog only (no per-step span structure)
+      - inline instrumentation in tools (couples observability to tool internals)
 
   - id: 9
     title: Orchestrator-owned multi-agent and git lifecycle
-    decision: Multi-agent coordination and git lifecycle management remain outside stitch runtime and are owned by the external orchestrator.
+    decision: |
+      Multi-agent coordination and git lifecycle management remain outside the
+      runtime and are owned by the external orchestrator. The runtime owns Machine
+      interpretation and tool dispatch.
     benefits:
-      - clear separation of concerns between orchestration and code generation
-      - smaller and more testable stitch runtime surface
+      - clear separation of concerns between orchestration and execution
+      - smaller and more testable runtime surface
     alternatives_rejected:
-      - embedding orchestrator responsibilities into stitch runtime
+      - embedding orchestrator responsibilities into the runtime
 
   - id: 10
-    title: Prompt-first Claude-like entry interface
-    decision: Stitch runtime exposes a prompt-first invoke interface and starts the internal loop upon invocation.
-    benefits:
-      - simple call contract for orchestrator integration
-      - clear lifecycle from invoke request to tool-driven loop execution
-    alternatives_rejected:
-      - multi-step external protocol to drive each loop turn manually
-
-  - id: 11
-    title: Hexagonal dependency inversion
-    decision: Runtime core depends only on inbound and outbound ports, while adapters implement concrete integrations.
-    benefits:
-      - lower coupling between domain logic and infrastructure
-      - adapter replacement without core rewrites
-    alternatives_rejected:
-      - direct core dependency on provider and filesystem implementations
-
-  - id: 13
     title: Orchestrator-owned isolation, runtime-owned path boundaries
     decision: |
       The cobbler orchestrator owns infrastructure isolation (podman containers,
-      network policy, filesystem mounts). The agent runtime is a Go library
-      invoked inside the container. It enforces workspace path boundaries on
-      mutation tools but does not create, manage, or assume any sandbox.
-      This matches the OpenHands and SWE-agent pattern where every orchestrated
-      agent delegates isolation to the deployment/orchestrator layer.
+      network policy, filesystem mounts). The agent runtime is a Go library invoked
+      inside the container. It enforces workspace path boundaries on mutation tools
+      but does not create, manage, or assume any sandbox.
     benefits:
       - agent library has no container or sandbox dependency
-      - isolation mechanism can change (podman, Docker, Kubernetes, bare metal) without agent changes
+      - isolation mechanism can change without agent changes
       - path boundary enforcement gives defence-in-depth inside the container
       - agent is testable without container infrastructure
     alternatives_rejected:
-      - agent-native sandboxing via seccomp or bubblewrap (claude-code CLI pattern, only appropriate for interactive CLI agents)
-      - no path enforcement at all (too risky even inside a container)
+      - agent-native sandboxing via seccomp or bubblewrap
+      - no path enforcement at all
 
-  - id: 14
+  - id: 11
     title: Agent as library invoked by cobbler
     decision: |
       The agent is a Go library package, not a standalone binary with its own
-      main(). The cobbler orchestrator imports and calls it. The entry point is
-      a function that takes configuration (provider, system prompt, workspace
-      path, tool allowlist) and a specification string, and returns when code
-      is produced or a blocker is reported. Observability uses standard Go
-      log/slog; cobbler reads logs from the shared logging infrastructure.
+      main(). The cobbler orchestrator imports and calls it. The entry point loads
+      the Machine and tool declarations, validates them, and enters the dispatch
+      loop.
     benefits:
       - no process boundary overhead between orchestrator and agent
       - orchestrator controls lifecycle, configuration injection, and teardown
-      - logging integrates with cobbler existing infrastructure (slog now, OpenTelemetry later)
       - simpler deployment (one binary, not two processes)
     alternatives_rejected:
-      - agent as separate process with RPC (goose ACP pattern, adds protocol complexity)
-      - agent as HTTP service (unnecessary for single-caller orchestrator)
+      - agent as separate process with RPC
+      - agent as HTTP service
 
-  - id: 15
+  - id: 12
+    title: Outcome classification taxonomy
+    decision: |
+      Execution outcomes are classified into a taxonomy: Clean (successful
+      completion), Recovery (completed after retries), Stuck (progress stalled),
+      Divergent (off-track). The Engine classifies the outcome on terminal state.
+      The orchestrator uses the classification to select a recovery strategy. This
+      is the Outcome Classifier pattern.
+    benefits:
+      - orchestrator gets a typed outcome, not a raw status code
+      - recovery decisions are data-driven, not heuristic
+      - degradation detection (prd024) is one signal within the taxonomy
+    alternatives_rejected:
+      - binary success/failure (no recovery or divergence signal)
+      - ad hoc status strings (no taxonomy, no static analysis)
+
+  - id: 13
     title: Tiered file editing — exact match then optional fuzzy fallback
     decision: |
-      edit_file uses a two-tier strategy. Tier 1 (prd022) is exact string
-      matching implemented with Go stdlib strings.Count and strings.Replace.
-      It ships in release 01.1 with zero external dependencies. Tier 2
-      (prd023) adds an optional fuzzy fallback using github.com/sergi/go-diff
-      (Go port of Google diff-match-patch) at Match_Threshold 0.95. It ships
-      in a later release behind a configuration flag (fuzzy_edit_enabled,
-      default false). Fuzzy matching activates only when exact match returns
-      edit_no_match, never on ambiguous matches. This mirrors the pattern
-      used by aider (Python dmp at 0.95) and opencode (same Go library).
+      edit_file uses a two-tier strategy. Tier 1 is exact string matching with Go
+      stdlib. Tier 2 adds an optional fuzzy fallback using
+      github.com/sergi/go-diff behind a configuration flag.
     benefits:
-      - release 01.1 ships with zero external dependencies for file editing
+      - zero external dependencies for exact matching
       - fuzzy fallback reduces wasted LLM round-trips on near-miss edits
-      - single external dependency (sergi/go-diff) is mature and used by opencode
       - fuzzy tier is behind a flag so it can be disabled in production
     alternatives_rejected:
-      - fuzzy-only from day one (unnecessary complexity for release 01.1)
-      - multi-tier aider-style cascade with git cherry-pick (diminishing returns, three additional dependencies)
-      - AST-aware matching (solves a different problem, doesn't help with LLM-generated text spans)
+      - fuzzy-only from day one
+      - multi-tier cascade with git cherry-pick
 
-  - id: 16
-    title: Loop trail branches_from orchestrator assignment crumb
+  - id: 14
+    title: Execution trail branches_from orchestrator assignment crumb
     decision: |
-      The LLM-tool loop runs inside its own crumbs trail. This trail is created
-      with a branches_from link to the assignment crumb in the orchestrator's
-      workflow trail. The loop runs in its own goroutine; invoke returns
-      immediately with the loop trail ID. The orchestrator observes outcome
-      by querying the loop trail state in the cupboard.
+      The dispatch loop runs inside its own crumbs trail. This trail is created with
+      a branches_from link to the assignment crumb in the orchestrator's workflow
+      trail. The loop runs in its own goroutine; invoke returns the trail ID
+      immediately. The orchestrator observes outcome by querying the trail state.
+    benefits:
+      - execution progress is observable without blocking the orchestrator
+      - trail branching uses crumbs' native branches_from link type
+      - orchestrator decides failure handling, not the Engine
+    alternatives_rejected:
+      - synchronous invoke that blocks until terminal state
+      - callback/channel notification
 
-      Each LLM response and tool result is a crumb in the loop trail. Token
-      usage is tracked in a stash scoped_to the trail. On success the trail
-      completes (crumbs cascade to pebble). On failure the trail is abandoned
-      (crumbs cascade to dust). The orchestrator reads the result crumb to
-      determine exit reason and decides the next action.
-    benefits:
-      - loop progress is observable without blocking the orchestrator
-      - trail branching uses crumbs' native branches_from and scoped_to link types
-      - completed/abandoned cascade gives clean pebble/dust semantics for audit
-      - orchestrator decides failure handling, not the loop
-    alternatives_rejected:
-      - synchronous invoke that blocks until loop finishes (prevents orchestrator concurrency)
-      - callback/channel notification (adds coupling; cupboard polling is sufficient)
-      - flat trail with no branching (loses the relationship to the orchestrator workflow)
-  - id: 17
-    title: Convergence detection via per-turn metrics and slope analysis
-    decision: |
-      The agent loop collects TurnMetrics after each turn: lines_changed,
-      tool_call_count, mutation_count, error_count, output_tokens. A sliding
-      window of recent turns is analyzed for two stall signals: (1) declining
-      edit volume detected via least-squares slope on lines_changed, and
-      (2) consecutive error turns indicating a fix-fail cycle. When either
-      signal fires, the loop exits with progress_stalled. The orchestrator
-      decides recovery strategy. Detection is optional and disabled by default.
-    benefits:
-      - detects LLM degradation that no reference agent (as of 2026-04) catches
-      - observe-only design — does not alter LLM context or tool availability
-      - orchestrator retains full control over recovery (retry, decompose, escalate)
-      - trivial implementation — linear regression on 3-8 data points, no libraries
-    alternatives_rejected:
-      - max_turns only (wastes remaining turns on unproductive work)
-      - injecting corrective prompts mid-loop (couples detection to recovery)
-      - token-rate monitoring alone (misses the edit-size signal)
-  - id: 18
+  - id: 15
     title: Language-agnostic agent with orchestrator-provided language context
     decision: |
-      The coding agent is language-agnostic. The orchestrator (cobbler)
-      determines the target programming language via workspace detection or
-      explicit configuration, then passes language and language_rules in the
-      AgentInvokeRequest. The system prompt template contains a
-      {language_rules} placeholder that the orchestrator fills with
-      language-specific conventions (idioms, naming, package layout, test
-      patterns). Mage remains the build system for all languages — the
-      orchestrator configures mage with language-appropriate targets via
-      magefile tags. The agent runtime itself is implemented in Go but does
-      not assume the generated code is Go.
+      The coding agent is language-agnostic. The orchestrator determines the target
+      programming language and passes language and language_rules in the
+      AgentInvokeRequest. The system prompt template contains a {language_rules}
+      placeholder. Mage remains the build system for all languages.
     benefits:
       - single agent runtime supports any language the orchestrator configures
-      - language rules live in constitutions owned by cobbler-scaffold, not the agent
+      - language rules live in constitutions, not the agent
       - no agent code changes needed to add a new language
-      - mage as universal build system simplifies the tool surface to one build_target tool
     alternatives_rejected:
-      - language detection inside the agent (duplicates orchestrator responsibility)
-      - separate agent binaries per language (unnecessary given prompt-driven behavior)
-      - hardcoded Go in the system prompt (prevents multi-language use)
-      - per-language build systems (mage can compile anything via tags)
+      - language detection inside the agent
+      - separate agent binaries per language
+      - hardcoded Go in the system prompt
 
 technology_choices:
   - component: Runtime language
     technology: Go
-    purpose: Typed contracts, interface boundaries, and deterministic runtime behavior.
+    purpose: Typed contracts, interface boundaries, and deterministic Engine behavior.
+  - component: Machine format
+    technology: YAML
+    purpose: Transition table as data — loadable, validatable, diffable.
+  - component: Tool declarations
+    technology: YAML
+    purpose: Tool contracts as data — parameter types, signals, undo modes.
   - component: Serialization
     technology: YAML and JSON
     purpose: Stash and call payload interchange.
-  - component: Validation strategy
-    technology: Typed struct decode plus tool-owned semantic validators
-    purpose: Clear separation of shape and semantic checks.
+  - component: Observability
+    technology: OpenTelemetry
+    purpose: Per-step span instrumentation for tool execution and Machine transitions.
   - component: Persistence model
     technology: Crumbs-compatible trail and crumb records
-    purpose: Auditable invocation and rollback history.
+    purpose: Auditable execution and rollback history.
 
 project_structure:
   - path: docs/VISION.yaml
@@ -520,11 +532,11 @@ project_structure:
     role: Validation suites mapped to use-case success criteria.
 
 implementation_status:
-  current_focus: Establish complete specification graph before code implementation.
+  current_focus: Re-align design docs to declarative agent patterns before code implementation.
   progress:
-    - item: Vision and architecture YAML drafted.
-    - item: Core PRDs for components, lifecycle, stash, invocation, and undo drafted.
-    - item: Use-case and test-suite specs pending.
+    - item: Vision and architecture YAML rewritten for State Interpreter and Declarative Agent patterns.
+    - item: PRDs being updated to reflect Engine, Machine, Registry, and Tool Contract.
+    - item: Use-case and test-suite specs pending alignment with declarative architecture.
 
 related_documents:
   - doc: VISION.yaml
@@ -532,9 +544,9 @@ related_documents:
   - doc: specs/component-catalog.yaml
     purpose: Canonical component list with responsibilities and dependency contracts.
   - doc: specs/interfaces/if001-llm-tool-adapter.yaml
-    purpose: Minimal async LLM invocation interface with prompt provenance and timeout semantics.
+    purpose: invoke_llm boundary tool interface with prompt provenance and signal emission.
   - doc: specs/interfaces/if002-agent-invoke-interface.yaml
-    purpose: Prompt-first invoke contract between orchestrator and stitch runtime.
+    purpose: Engine entry point contract between orchestrator and runtime.
   - doc: specs/interfaces/if003-workspace-discovery-read-port.yaml
     purpose: Port contract for find_files, find_text, and read_file operations.
   - doc: specs/interfaces/if004-workspace-mutation-port.yaml
@@ -546,8 +558,8 @@ related_documents:
   - doc: specs/interfaces/if007-message-history.yaml
     purpose: Trail-backed conversation history with crumbs-persisted messages.
   - doc: specs/interfaces/if008-tool-schemas.yaml
-    purpose: MCP-compatible tool schemas for the eight essential tools.
+    purpose: MCP-compatible tool schemas for the essential tools.
   - doc: specs/interfaces/if009-provider-config.yaml
     purpose: Ollama and AWS Bedrock provider configuration and client abstraction.
   - doc: specs/interfaces/if010-agent-loop-state-machine.yaml
-    purpose: Loop state machine with turn lifecycle, termination conditions, and trail model.
+    purpose: Machine data structure with states, signals, transitions, and terminal states.

--- a/docs/SPECIFICATIONS.yaml
+++ b/docs/SPECIFICATIONS.yaml
@@ -134,9 +134,25 @@ prd_index:
     summary: Define the optional fuzzy fallback for edit_file using diff-match-patch.
     path: specs/product-requirements/prd023-fuzzy-match-file-editing.yaml
   - id: prd024-llm-degradation-detection
-    title: LLM Degradation Detection
-    summary: Define per-turn metrics, always-on loop statistics, and degradation signals for progress_stalled exit.
+    title: Outcome Classifier
+    summary: Define four-valued convergence taxonomy (Clean, Recovery, Stuck, Divergent) and pure classifier function from execution to type.
     path: specs/product-requirements/prd024-llm-degradation-detection.yaml
+  - id: prd027-trace-instrumentation
+    title: Trace Instrumentation
+    summary: Define Tracer port, four-type OpenTelemetry span tree, and W3C trace context propagation.
+    path: specs/product-requirements/prd027-trace-instrumentation.yaml
+  - id: prd028-agent-delegation
+    title: Agent Delegation
+    summary: Define non-terminal boundary tools that compose sub-machines and child agents with independent audit.
+    path: specs/product-requirements/prd028-agent-delegation.yaml
+  - id: prd029-approval-gate
+    title: Approval Gate
+    summary: Define checkpoint-based suspension at declared Machine states with resume and rollback paths.
+    path: specs/product-requirements/prd029-approval-gate.yaml
+  - id: prd030-runtime-probe
+    title: Runtime Probe
+    summary: Define control-plane server for live state inspection and machine-validated signal injection.
+    path: specs/product-requirements/prd030-runtime-probe.yaml
 
 use_case_index:
   - id: rel01.0-uc001-agentic-loop-core

--- a/docs/VISION.yaml
+++ b/docs/VISION.yaml
@@ -2,103 +2,156 @@ id: press
 title: Press Vision
 
 executive_summary: |
-  Press is the agent runtime that turns specifications into code. Cobbler composes the work,
-  crumbs holds the pieces, and press prints the output — like a printing press transferring
-  composed type to paper.
+  Press is a declarative agent runtime that turns specifications into code. Cobbler
+  composes the work, crumbs holds the pieces, and press prints the output — like a
+  printing press transferring composed type to paper.
 
-  Workflows are tracked as trails, tool execution attempts are tracked as crumbs, and tool
-  availability is scoped by stashes. The model proposes tool calls. The runtime enforces
-  stash gating, typed argument decoding, semantic validation, execution boundaries, and
-  structured error reporting. We support undo and compensation where tools declare rollback
-  capability.
+  The agent is a dataset, not a program. A Machine defines states, signals, and
+  transitions as a YAML transition table. An Engine interprets the Machine. Tools
+  declare parameter types, emittable signals, and undo modes in tool contracts.
+  The Engine dispatches tools, routes signals, and records execution as crumbs in
+  trail scope. One binary interprets any agent whose YAML conforms to the schema.
 
 problem: |
-  Agent loops often mix planning, authorization, execution, and history in one opaque control
-  path. This causes recurring failure modes.
+  Agent loops mix planning, authorization, execution, and history in one opaque
+  imperative control path. The state machine is implicit — buried in if/elif
+  branches inside a loop function. This causes recurring failure modes.
 
-  1. Tools run outside intended workflow context.
-  2. Arguments pass shape checks but fail semantic intent.
-  3. Permission failures are inconsistent across tools.
-  4. Side effects are difficult to roll back.
-  5. Audit and replay are incomplete.
+  1. Control flow is code, not data. Reviewers cannot read, diff, or validate the
+     workflow without tracing every path through the loop.
+  2. Tool outcomes are untyped. The loop classifies responses ad hoc — terminal
+     vs actionable, success vs failure — with no closed-world signal set.
+  3. Tools run outside their intended state. Without per-state scoping, any tool
+     can fire at any time, violating workflow invariants.
+  4. Side effects are difficult to roll back. Without per-tool Undo and
+     machine-level execution recording, rollback is heuristic.
+  5. Audit and replay are incomplete. The imperative loop's history is a log, not
+     a structured execution record that a machine can replay.
+  6. Agent definitions are not portable. Behaviour is buried in code, config, and
+     deployment scripts, so agents cannot be versioned, composed, or swapped as
+     units.
 
 what_this_does: |
-  We provide a deterministic runtime control plane for model-driven tool invocation.
+  We provide a declarative runtime where the agent is a dataset the Engine
+  interprets.
 
-  1. Trail-scoped workflow lifecycle.
-  2. Stash-scoped tool availability.
-  3. Typed decoding for JSON and YAML payloads.
-  4. Semantic validation before invocation.
-  5. Structured execution and permission failure reporting.
-  6. Crumb-based audit records for accepted and rejected calls.
-  7. Undo and compensation flows driven by declared tool modes.
+  1. Machine as transition table — states, signals, and transitions in YAML, with
+     no logic, conditionals, or loops.
+  2. Engine as fixed interpreter — a generic dispatch loop that consults the
+     Machine, resolves tools through the Registry, and routes signals.
+  3. Tool contracts — each tool declares parameter types, emittable signals, undo
+     mode, and side effects. The Machine is statically validated against every
+     tool's signal set before execution.
+  4. Per-state tool scoping — tool availability is driven by Machine state, not
+     only trail-scoped.
+  5. Boundary tools — invoke_llm is one tool among many, declared in the Machine
+     with its signal set, not special-cased in Engine code.
+  6. Crumb-based execution recording — each dispatch cycle records state, signal,
+     tool, and result as a crumb in trail scope.
+  7. Per-tool Undo and Engine-driven rollback — the Engine walks execution
+     backward, calling each tool's Undo method with its recorded result.
+  8. Outcome classification — execution outcomes are classified into a taxonomy
+     (Clean, Recovery, Stuck, Divergent) for orchestrator recovery decisions.
 
 why_we_build_this: |
-  We need coding agents that can run tools on real systems without losing control of safety,
-  traceability, and recoverability. Cobbler owns the workflow. Crumbs owns the storage.
-  Press owns the execution. The crumbs model gives us the right primitives for this runtime
-  design.
+  We need coding agents that run tools on real systems without losing control of
+  safety, traceability, and recoverability. Cobbler owns the workflow. Crumbs
+  owns the storage. Press owns the execution. The declarative agent pattern gives
+  us the right primitives for this runtime design.
 
-  1. Trail as workflow boundary.
-  2. Crumb as invocation ledger item.
-  3. Stash as capability boundary.
-  4. Link-based lineage for dependencies and rollback context.
+  1. Machine as workflow boundary — the transition table defines what can happen
+     and in what order.
+  2. Crumb as execution ledger item — each dispatch cycle is auditable and
+     replayable.
+  3. Tool contract as capability boundary — parameter types, signals, and undo
+     modes are declared, not discovered at runtime.
+  4. Signal as typed outcome — the closed-world signal set enables static
+     validation before execution.
+  5. Engine as fixed interpreter — one binary runs any agent whose YAML conforms
+     to the schema.
 
 success_criteria:
-  invocation_persistence: |
-    Every invocation attempt persists one crumb with deterministic outcome metadata.
-  stash_gating: |
-    No tool executes unless enabled in the active stash.
-  validation_enforcement: |
-    Decode and semantic failures are rejected before invocation.
-  error_reporting: |
-    Permission and OS failures are surfaced as structured execution errors.
-  rollback_reporting: |
-    Trail rollback reports include success, failure, skipped, and non-reversible counts.
+  machine_validation: |
+    Every referenced state-signal pair exists, every tool name resolves, and every
+    signal a tool emits is handled in every state where it can be dispatched.
+    Validation runs at load time, before any tool executes.
+  signal_routing: |
+    Every tool returns a typed signal. The Engine routes the next transition from
+    the Machine. No ad hoc classification in Engine code.
+  per_state_scoping: |
+    Tool availability is driven by Machine state. Tools not declared for the
+    current state cannot execute.
+  execution_recording: |
+    Every dispatch cycle persists one crumb with state, signal, tool, and result
+    metadata. The execution record reconstructs without re-running anything.
+  rollback: |
+    The Engine walks execution backward, calling each tool's Undo with its
+    recorded result. Rollback reports include success, failure, skipped, and
+    non-reversible counts.
+  outcome_classification: |
+    Execution outcomes are classified into a taxonomy (Clean, Recovery, Stuck,
+    Divergent) for orchestrator recovery decisions.
 
 implementation_phases:
   - phase: "01.0"
-    focus: Foundation contracts and trail lifecycle
+    focus: Declarative core — Machine, Engine, Registry
     deliverables: |
-      ARCHITECTURE.yaml, prd001-tool-system-components-interfaces,
-      prd002-trail-lifecycle-state-machine.
+      ARCHITECTURE.yaml, VISION.yaml, prd001-tool-system-components-interfaces
+      (Engine, Machine, Registry), prd002-trail-lifecycle-state-machine
+      (Machine state lifecycle), prd004-tool-invocation-validation
+      (Tool Contract validation).
   - phase: "01.1"
-    focus: Stash and invocation controls
+    focus: Toolset scoping, model adapter, and trace instrumentation
     deliverables: |
-      prd003-tool-stash-availability, prd004-tool-invocation-validation,
-      prd006-stitch-essential-toolset, prd007-file-read-search-and-mutation-safety,
+      prd003-tool-stash-availability (Scoped Toolset), prd006-stitch-essential-toolset
+      (Model Adapter), prd007-file-read-search-and-mutation-safety,
       prd008-mage-task-execution-and-diagnostics, prd009-hexagonal-ports-and-wiring,
-      prd010-prompt-library-and-composition, interface specifications.
+      prd010-prompt-library-and-composition, prd027-trace-instrumentation,
+      interface specifications.
   - phase: "02.0"
-    focus: Undo and compensation
+    focus: Execution rollback and agent delegation
     deliverables: |
-      prd005-undo-and-compensation.
+      prd005-undo-and-compensation (per-tool Undo), prd028-agent-delegation,
+      prd029-approval-gate.
   - phase: "03.0"
-    focus: Hardening and measurable validation
+    focus: Outcome classification, runtime probe, and validation
     deliverables: |
-      Use-case specifications, test-suite specifications,
-      ts001-ports-and-adapters-contracts.
+      prd024-llm-degradation-detection (Outcome Classifier), prd030-runtime-probe,
+      use-case specifications, test-suite specifications.
 
 risks:
-  - risk: Overscoped stashes allow unsafe tools
-    impact: High
-    likelihood: Medium
-    mitigation: Deny-by-default stash policy and explicit stash review controls.
-  - risk: Semantic drift between validators and tool behavior
+  - risk: Machine signal explosion
     impact: Medium
     likelihood: Medium
-    mitigation: Keep validators in tool packages and enforce contract tests.
+    mitigation: Group signals, encapsulate sub-workflows in non-terminal tools, and
+      generate machine skeletons from tool declarations.
+  - risk: Implicit data flow
+    impact: Medium
+    likelihood: High
+    mitigation: The Machine declares control flow but not data flow. A builder
+      bridges tool outputs to inputs. Type-checking data flow requires an analysis
+      layer beyond the Machine.
   - risk: Partial rollback for non-reversible tools
     impact: High
     likelihood: High
-    mitigation: Require explicit undo modes and unresolved side-effect reporting.
+    mitigation: Require explicit undo modes in tool contracts and unresolved
+      side-effect reporting.
   - risk: Crumb growth degrades query performance
     impact: Medium
     likelihood: Medium
     mitigation: Pagination, retention windows, and archival policies.
+  - risk: Imperative floor in Engine and adapters
+    impact: Low
+    likelihood: High
+    mitigation: Engine internals, port adapters, and type factories remain compiled
+      Go. Adding a new tool type or provider means writing code, not YAML. Accept
+      this boundary — the declarative layer covers agent behaviour, not runtime
+      infrastructure.
 
 not:
   - We are not a predefined workflow orchestration engine.
   - We are not a message queue.
   - We are not a model training or prompt-tuning platform.
   - We do not guarantee full rollback for non-reversible tools.
+  - We do not compile machines to code — the Engine interprets the Machine at
+    runtime.

--- a/docs/road-map.yaml
+++ b/docs/road-map.yaml
@@ -3,11 +3,12 @@ title: Press Roadmap
 
 releases:
   - version: "01.0"
-    name: Agent Runtime Core Contracts
+    name: Declarative Core — Machine, Engine, Registry
     status: specs_done
     depends_on: []
     description: |
-      Trail lifecycle, stash gating, invocation validation, and undo semantics.
+      Machine state lifecycle, Engine dispatch loop, Registry tool resolution,
+      Tool Contract validation, and outcome classification.
     use_cases:
       - id: rel01.0-uc001-agentic-loop-core
         summary: Prompt to trail mapping and LLM-as-tool loop routing
@@ -46,6 +47,9 @@ releases:
       - id: rel01.1-uc004-prompt-library-baseline
         summary: Prompt family inventory composition and provenance contract
         status: pending
+      - id: rel01.1-uc005-trace-instrumentation
+        summary: OpenTelemetry span instrumentation per tool and transition
+        status: pending
   - version: "01.3"
     name: Comparative Conformance Evaluation
     status: not_started
@@ -57,17 +61,24 @@ releases:
         summary: Evaluate runtime against conformance baselines
         status: pending
   - version: "02.0"
-    name: Undo and Compensation Delivery
+    name: Execution Rollback and Agent Delegation
     status: not_started
     depends_on: ["01.0"]
     description: |
-      Implement and validate rollback and compensation contracts.
+      Implement per-tool Undo, Engine-driven rollback, agent delegation,
+      and approval gate contracts.
     use_cases:
       - id: rel02.0-uc001-rollback-execution
         summary: Reverse-order undo planning and execution
         status: pending
       - id: rel02.0-uc002-partial-failure-reporting
         summary: Partial rollback and unresolved side-effect reporting
+        status: pending
+      - id: rel02.0-uc003-agent-delegation
+        summary: Non-terminal boundary tools composing sub-machines
+        status: pending
+      - id: rel02.0-uc004-approval-gate
+        summary: Checkpoint-based suspension and resume on external decision
         status: pending
   - version: "03.0"
     name: Hardening and Measurable Validation
@@ -86,7 +97,10 @@ releases:
         summary: Ports and adapters contract conformance suite
         status: pending
       - id: rel03.0-uc004-llm-degradation-detection
-        summary: Per-turn metrics collection, always-on statistics, and degradation signal detection
+        summary: Outcome classification taxonomy and convergence detection
+        status: pending
+      - id: rel03.0-uc005-runtime-probe
+        summary: Live state inspection and machine-validated signal injection
         status: pending
   - version: "99.0"
     name: Unscheduled

--- a/docs/specs/component-catalog.yaml
+++ b/docs/specs/component-catalog.yaml
@@ -1,30 +1,76 @@
 id: component-catalog
-title: Agent Runtime Component Catalog
+title: Declarative Agent Runtime Component Catalog
 
 purpose: |
-  Define the canonical runtime components, their responsibilities, contracts,
-  dependencies, and ownership boundaries.
+  Define the canonical runtime components for the declarative agent architecture,
+  their responsibilities, contracts, dependencies, and ownership boundaries.
 
 components:
-  - id: C13
-    name: StitchBoundaryAdapter
-    domain: integration
-    responsibility: Bridge orchestrator assignments to stitch runtime execution context and return stitch results.
-    provides:
-      - accept_assignment
-      - build_execution_context
-      - invoke_with_prompt
-      - emit_execution_result
-    consumes:
-      - AgentLoopOrchestrator for runtime execution
-      - CrumbLedger for execution summary extraction
-    dependencies:
-      - specs/use-cases/uc002-orchestrator-stitch-boundary.yaml
-
   - id: C01
+    name: Engine
+    domain: core
+    responsibility: Interpret the Machine. Run the dispatch loop, resolve tools through the Registry, record crumbs, and route signals to transitions.
+    provides:
+      - run
+      - resume
+      - rollback
+      - history
+      - classify_outcome
+    consumes:
+      - Machine for transition lookup
+      - Registry for tool resolution
+      - CrumbLedger for execution recording
+    dependencies:
+      - prd001-tool-system-components-interfaces
+
+  - id: C02
+    name: Machine
+    domain: data
+    responsibility: Pure data structure mapping (state, signal) to (next_state, action). No logic, conditionals, or loops.
+    provides:
+      - transitions
+      - initial_state
+      - terminal_states
+      - per_state_tool_visibility
+    consumes:
+      - none
+    dependencies:
+      - prd002-trail-lifecycle-state-machine
+
+  - id: C03
+    name: Registry
+    domain: tools
+    responsibility: Resolve tool names to implementations at load time. Hold tool declarations with parameter types, signal sets, undo modes, and side effects.
+    provides:
+      - resolve_tool
+      - get_declaration
+      - list_tools
+      - validate_signals
+    consumes:
+      - none
+    dependencies:
+      - prd001-tool-system-components-interfaces
+      - prd004-tool-invocation-validation
+
+  - id: C04
+    name: ToolContractValidator
+    domain: validation
+    responsibility: Validate tool declarations against the Machine at load time. Check signal completeness, tool name resolution, and parameter type matching.
+    provides:
+      - validate_machine_against_tools
+      - check_signal_completeness
+      - verify_tool_resolution
+      - check_parameter_types
+    consumes:
+      - Machine for transition references
+      - Registry for tool declarations
+    dependencies:
+      - prd004-tool-invocation-validation
+
+  - id: C05
     name: TrailManager
     domain: lifecycle
-    responsibility: Own trail lifecycle transitions and stash binding.
+    responsibility: Own execution trail lifecycle and stash binding.
     provides:
       - create_trail
       - activate_trail
@@ -32,278 +78,140 @@ components:
       - abandon_trail
     consumes:
       - CrumbLedger for transition events
-      - StashManager for activation guard checks
     dependencies:
       - prd002-trail-lifecycle-state-machine
 
-  - id: C02
-    name: StashManager
-    domain: policy
-    responsibility: Resolve active stash and evaluate tool eligibility.
+  - id: C06
+    name: StitchBoundaryAdapter
+    domain: integration
+    responsibility: Translate orchestrator assignment envelopes to internal execution context. Load Machine and tool declarations, start the Engine, and return execution results.
     provides:
-      - resolve_active_stash
-      - is_tool_enabled
-      - get_tool_policy_mode
+      - accept_assignment
+      - load_machine_and_tools
+      - start_engine
+      - emit_execution_result
     consumes:
-      - ToolRegistry for descriptor reconciliation
-      - CrumbLedger for availability decision records
+      - Engine for dispatch loop execution
+      - CrumbLedger for execution summary extraction
     dependencies:
-      - prd003-tool-stash-availability
+      - specs/use-cases/rel01.0-uc002-orchestrator-stitch-boundary.yaml
 
-  - id: C03
-    name: ToolRegistry
-    domain: metadata
-    responsibility: Maintain tool descriptors and adapter bindings.
-    provides:
-      - get_descriptor
-      - list_descriptors
-      - get_undo_mode
-      - resolve_adapter
-    consumes:
-      - none
-    dependencies:
-      - prd001-tool-system-components-interfaces
-
-  - id: C12
+  - id: C07
     name: LLMToolAdapter
     domain: tools
     responsibility: |
-      Execute llm.generate against configured providers with built-in instrumentation.
-      Hide all provider-specific wire formats (OpenAI function_call, Anthropic tool_use,
-      Ollama tool_calls). Parse raw model output into ToolCallIntent objects with
-      syntactically valid JSON arguments before returning to the caller. Operates like
-      the Ollama chat API: the caller receives a clean tool_calls list, never raw
-      provider responses.
+      Implement the invoke_llm boundary tool. Build prompts from stash references
+      and crumb context via PromptAssembler. Invoke configured LLM providers through
+      ProviderAdapter. Parse responses via ResponseParser. Emit LLMResponded or
+      BudgetExceeded signals.
     provides:
-      - compose_prompt_from_crumb_and_stash
-      - invoke_provider_async
-      - parse_tool_calls
-      - enforce_provider_timeout
-      - record_provider_metrics
-      - normalize_provider_failure
+      - execute
+      - undo
+      - compose_prompt
+      - invoke_provider
+      - parse_response
     consumes:
-      - ToolRegistry for provider binding and model configuration
-      - StashManager for prompt reference resolution
+      - Registry for tool declaration
       - CrumbLedger for prompt reference and result metadata persistence
     dependencies:
-      - prd001-tool-system-components-interfaces
+      - prd006-stitch-essential-toolset
       - prd004-tool-invocation-validation
 
-  - id: C04
-    name: ToolCallInterpreter
-    domain: invocation
-    responsibility: Normalize provider-native and parsed outputs into canonical ToolCall.
-    provides:
-      - normalize_tool_call
-      - assign_call_correlation
-    consumes:
-      - ToolRegistry for descriptor verification
-    dependencies:
-      - prd001-tool-system-components-interfaces
-      - prd004-tool-invocation-validation
-
-  - id: C05
-    name: InvocationValidator
-    domain: validation
-    responsibility: Enforce validation order from availability to semantic checks.
-    provides:
-      - validate_availability
-      - decode_typed_args
-      - validate_semantics
-    consumes:
-      - StashManager for availability decisions
-      - ToolRegistry for schemas and validators
-    dependencies:
-      - prd004-tool-invocation-validation
-
-  - id: C06
-    name: PermissionExecutor
-    domain: execution
-    responsibility: Execute validated calls and return structured runtime failures.
-    provides:
-      - execute_call
-      - execute_call_async
-      - enforce_execution_timeout
-      - map_runtime_failure
-    consumes:
-      - ToolRegistry for adapter execution binding
-      - ToolEventBus for execution announcements
-    dependencies:
-      - prd004-tool-invocation-validation
-
-  - id: C07
+  - id: C08
     name: CrumbLedger
     domain: audit
-    responsibility: Persist primary, rejection, and undo crumbs with correlations.
+    responsibility: Persist execution and undo outcomes as crumbs. Each dispatch cycle records state, signal, tool, and result metadata.
     provides:
-      - write_invocation_crumb
+      - write_execution_crumb
       - write_rejection_crumb
       - write_undo_crumb
       - query_trail_crumbs
     consumes:
-      - ToolEventBus events
-    dependencies:
-      - prd001-tool-system-components-interfaces
-      - prd005-undo-and-compensation
-
-  - id: C08
-    name: UndoManager
-    domain: recovery
-    responsibility: Plan and execute reverse-order undo and compensation.
-    provides:
-      - build_undo_plan
-      - execute_undo_plan
-      - summarize_rollback
-    consumes:
-      - CrumbLedger for source crumbs and undo records
-      - ToolRegistry for mode and undo adapter resolution
-    dependencies:
-      - prd005-undo-and-compensation
-
-  - id: C09
-    name: ToolEventBus
-    domain: observability
-    responsibility: Emit lifecycle announcements for selection, validation, execution, and rollback.
-    provides:
-      - emit_tool_call_received
-      - emit_validation_rejected
-      - emit_invocation_succeeded
-      - emit_invocation_failed
-      - emit_undo_step_result
-    consumes:
       - none
     dependencies:
       - prd001-tool-system-components-interfaces
+      - prd005-undo-and-compensation
+
+  - id: C09
+    name: UndoManager
+    domain: recovery
+    responsibility: Walk execution backward via recorded crumbs, calling each tool's Undo with its recorded result. Report success, failure, skipped, and non-reversible counts.
+    provides:
+      - walk_backward
+      - call_undo
+      - summarize_rollback
+    consumes:
+      - CrumbLedger for source crumbs and undo records
+      - Engine for rollback dispatch
+    dependencies:
+      - prd005-undo-and-compensation
 
   - id: C10
-    name: AgentLoopOrchestrator
-    domain: orchestration
-    responsibility: Receive prompt input, map prompt to trail context, and drive iterative loop turns.
+    name: TraceAdapter
+    domain: observability
+    responsibility: Emit OpenTelemetry spans per tool execution and Machine transition. Provide per-step observability without modifying the Machine or tools.
     provides:
-      - receive_prompt
-      - map_prompt_to_trail
-      - start_loop_turn
-      - finish_loop_turn
+      - start_span
+      - end_span
+      - record_event
+      - set_attribute
+      - propagate_context
     consumes:
-      - TrailManager for trail lookup and lifecycle guards
-      - ToolCallInterpreter for canonical LLM tool call normalization
-      - InvocationValidator for loop-turn validation flow
-      - PermissionExecutor for loop-turn execution
-      - ModelResponseRouter for post-LLM branch mapping
+      - Engine dispatch events
     dependencies:
-      - prd002-trail-lifecycle-state-machine
-      - prd004-tool-invocation-validation
-
-  - id: C11
-    name: ModelResponseRouter
-    domain: orchestration
-    responsibility: Map LLM tool output to either crumb insertion or next tool invocation.
-    provides:
-      - classify_llm_output
-      - map_to_crumb_insert
-      - map_to_next_invocation
-    consumes:
-      - CrumbLedger for insertion records
-      - ToolCallInterpreter for next-call normalization
-      - ToolEventBus for branch announcements
-    dependencies:
-      - prd001-tool-system-components-interfaces
-      - prd004-tool-invocation-validation
+      - prd027-trace-instrumentation
 
 contracts:
   entry_interface:
     method: invoke
-    shape: invoke(prompt, assignment_id, trail_id)
+    shape: invoke(prompt, assignment_id, trail_id, machine_ref, tool_roots)
     behavior:
       - Called after orchestrator environment and tool configuration are complete.
-      - Starts loop execution within AgentLoopOrchestrator.
-      - Returns terminal output and execution summary envelope.
+      - Loads Machine and tool declarations, validates against each other.
+      - Starts Engine dispatch loop.
+      - Returns execution trail ID immediately.
   sequencing:
-    - StitchBoundaryAdapter accepts orchestrator assignment before loop start
-    - StitchBoundaryAdapter initializes stitch context before AgentLoopOrchestrator receives prompt
-    - StitchBoundaryAdapter invoke_with_prompt starts AgentLoopOrchestrator loop
-    - AgentLoopOrchestrator receives prompt before any loop tool call
-    - AgentLoopOrchestrator maps prompt to trail before LLM invocation
-    - AgentLoopOrchestrator invokes LLM through the same interpreter, validator, and executor pipeline as any tool
-    - LLMToolAdapter composes prompt from crumb context and stash references before provider invocation
-    - LLMToolAdapter executes provider calls asynchronously with timeout and failure normalization
-    - ToolCallInterpreter before InvocationValidator
-    - InvocationValidator before PermissionExecutor
-    - PermissionExecutor LLM result before ModelResponseRouter branch decision
-    - ModelResponseRouter maps to crumb insertion or next invocation before next loop turn
-    - PermissionExecutor before CrumbLedger primary write
+    - StitchBoundaryAdapter accepts orchestrator assignment before Engine start
+    - StitchBoundaryAdapter loads Machine and tool declarations before validation
+    - ToolContractValidator validates Machine against tool signal sets before any dispatch
+    - Engine enters initial state before first tool dispatch
+    - Engine resolves tool through Registry before Execute
+    - LLMToolAdapter composes prompt before provider invocation
+    - Engine records crumb after each committed transition
+    - Engine routes signal to next transition via Machine lookup
+    - Engine classifies outcome on terminal state
     - UndoManager after trail abandon or explicit rollback request
   invariants:
-    - Stitch runtime does not execute git lifecycle operations.
-    - Stitch runtime does not coordinate multiple peer agents.
-    - LLM is represented as a tool descriptor and never bypasses tool contracts.
-    - LLM provider instrumentation is owned by LLMToolAdapter, not by a separate proxy component.
-    - Prompt fragments are configured in stash and referenced or attached in crumbs.
-    - Every loop turn has one LLM invocation attempt crumb.
-    - Every LLM result is mapped to exactly one branch decision.
-    - No component bypasses stash availability checks.
-    - No execution occurs after decode or semantic validation failure.
-    - Every invocation attempt results in exactly one primary crumb.
+    - Runtime does not execute git lifecycle operations.
+    - Runtime does not coordinate multiple peer agents.
+    - invoke_llm is a boundary tool declared in the Machine, never special-cased in Engine code.
+    - Every signal a tool emits is handled by the Machine.
+    - Every dispatch cycle produces exactly one crumb.
+    - No tool executes unless declared in the current state's visibility list.
+    - Machine validation runs at load time, before any tool executes.
     - Every undo step produces an undo result record.
-
-agentic_loop:
-  canonical_flow:
-    - step: 1
-      action: Receive prompt
-      owner: AgentLoopOrchestrator
-      output: prompt envelope with correlation id
-    - step: 2
-      action: Map prompt to trail
-      owner: AgentLoopOrchestrator
-      output: active trail id or newly created trail id
-    - step: 3
-      action: Invoke LLM as tool call
-      owner: AgentLoopOrchestrator
-      output: canonical ToolCall with tool_name llm.generate
-    - step: 4
-      action: Execute standard validation and invocation pipeline
-      owner: ToolCallInterpreter, InvocationValidator, PermissionExecutor, LLMToolAdapter
-      output: structured LLM tool result
-    - step: 5
-      action: Route model response
-      owner: ModelResponseRouter
-      output: branch decision
-  branch_rules:
-    - condition: LLM output has no executable tool call intents
-      branch: crumb_insertion
-      effects:
-        - insert output crumb
-        - emit loop turn completed event
-    - condition: LLM output has executable tool call intents
-      branch: next_crumb_invocation
-      effects:
-        - normalize next tool call
-        - enqueue next invocation crumb
-        - continue loop turn
 
 ownership_model:
   runtime_core:
-    - AgentLoopOrchestrator
+    - Engine
+    - Machine
+    - Registry
+    - ToolContractValidator
     - TrailManager
-    - ToolCallInterpreter
-    - InvocationValidator
-    - PermissionExecutor
-    - ModelResponseRouter
     - UndoManager
   runtime_services:
     - StitchBoundaryAdapter
-    - StashManager
-    - ToolRegistry
     - LLMToolAdapter
     - CrumbLedger
-    - ToolEventBus
+    - TraceAdapter
 
 hexagonal_classification:
   core_domain_services:
-    - AgentLoopOrchestrator
+    - Engine
+    - Machine
+    - Registry
+    - ToolContractValidator
     - TrailManager
-    - InvocationValidator
-    - ModelResponseRouter
     - UndoManager
   inbound_ports:
     - AgentInvokePort
@@ -313,6 +221,7 @@ hexagonal_classification:
     - WorkspaceMutationPort
     - ValidationPort
     - StateAuditPorts
+    - TracePort
   driving_adapters:
     - StitchBoundaryAdapter
   driven_adapters:
@@ -321,47 +230,46 @@ hexagonal_classification:
     - WorkspaceMutationAdapter
     - ValidationAdapter
     - StateAuditAdapter
+    - TraceAdapter
   dependency_rule:
     - Core depends on ports only.
     - Adapters implement ports and isolate infrastructure specifics.
 
 wiring_map:
   inbound:
-    - StitchBoundaryAdapter -> AgentInvokePort -> AgentLoopOrchestrator
+    - StitchBoundaryAdapter -> AgentInvokePort -> Engine
   outbound:
-    - AgentLoopOrchestrator -> LLMInvocationPort -> LLMToolAdapter
-    - AgentLoopOrchestrator -> WorkspaceDiscoveryReadPort -> WorkspaceDiscoveryAdapter
-    - AgentLoopOrchestrator -> WorkspaceMutationPort -> WorkspaceMutationAdapter
-    - AgentLoopOrchestrator -> ValidationPort -> ValidationAdapter
-    - AgentLoopOrchestrator -> StateAuditPorts -> StateAuditAdapter
+    - Engine -> LLMInvocationPort -> LLMToolAdapter
+    - Engine -> WorkspaceDiscoveryReadPort -> WorkspaceDiscoveryAdapter
+    - Engine -> WorkspaceMutationPort -> WorkspaceMutationAdapter
+    - Engine -> ValidationPort -> ValidationAdapter
+    - Engine -> StateAuditPorts -> StateAuditAdapter
+    - Engine -> TracePort -> TraceAdapter
 
 minimal_profile:
   included_now:
+    - Engine
+    - Machine
+    - Registry
+    - ToolContractValidator
     - TrailManager
-    - StashManager
-    - ToolRegistry
+    - StitchBoundaryAdapter
     - LLMToolAdapter
-    - ToolCallInterpreter
-    - InvocationValidator
-    - PermissionExecutor
-    - AgentLoopOrchestrator
-    - ModelResponseRouter
     - CrumbLedger
     - UndoManager
-    - ToolEventBus
+    - TraceAdapter
   assumptions:
     - Orchestrator performs multi-agent assignment and coordination.
     - Orchestrator prepares environment before invoke.
     - Orchestrator configures allowed tools before invoke.
     - Orchestrator performs git branch and merge management.
-    - Tool set is pre-configured.
+    - Machine and tool declarations are YAML files.
     - MCP integration is not required for first delivery.
-    - CLI tool invocation can be added as a standard tool adapter.
   deferred_or_optional:
-    - SubAgentExecutor as an optional tool.
+    - Agent Delegation (prd028) as non-terminal boundary tools.
+    - Approval Gate (prd029) as Machine transition.
+    - Runtime Probe (prd030) as control-plane server.
     - MCPInvokeTool as a configurable integration tool.
-    - CLITool as a configurable shell adapter tool.
-    - Provider proxy service if direct SDK calls become insufficient.
 
 status:
   component_catalog: complete
@@ -373,6 +281,7 @@ status:
     - if004-workspace-mutation-port
     - if005-validation-port
     - if006-state-and-audit-ports
+    - if010-agent-loop-state-machine
   contract_test_suites:
     - ts001-ports-and-adapters-contracts
   implementation_bindings: pending

--- a/docs/specs/interfaces/if001-llm-tool-adapter.yaml
+++ b/docs/specs/interfaces/if001-llm-tool-adapter.yaml
@@ -1,21 +1,22 @@
 id: if001-llm-tool-adapter
-title: LLMToolAdapter Interface Contract
+title: invoke_llm Boundary Tool Interface Contract
 component: LLMToolAdapter
 
 purpose: |
-  Define the minimal request and response contracts for llm.generate execution
-  with prompt reference resolution, asynchronous provider invocation, timeout
-  behavior, and instrumentation output.
+  Define the invoke_llm boundary tool contract for model inference. invoke_llm is
+  the only tool that crosses the inference boundary, declared in the Machine with
+  signal set LLMResponded and BudgetExceeded. The Model Adapter pattern places all
+  inference behind this one tool and a pluggable ProviderAdapter.
 
-  The LLM object operates like the Ollama chat API: it hides all provider-specific
-  details of mapping raw model output to tool calls. When the response leaves the
-  LLM boundary, tool_calls is a list of ToolCallIntent objects whose arguments are
-  syntactically valid JSON. The caller never sees raw provider wire formats,
-  partial JSON strings, or provider-specific tool_use blocks.
+  The PromptAssembler builds provider-agnostic prompts from current state,
+  conversation history, and the state-filtered manifest. The ProviderAdapter
+  translates to the provider's API format. The ResponseParser normalizes the reply
+  into ToolCallIntent objects with syntactically valid JSON arguments. The caller
+  never sees raw provider wire formats.
 
 dependencies:
-  - ToolRegistry
-  - StashManager
+  - Registry
+  - PromptAssembler
   - CrumbLedger
 
 types:
@@ -54,7 +55,7 @@ types:
         type: string
       tool_name:
         type: string
-        const: llm.generate
+        const: invoke_llm
       provider:
         type: string
       model:
@@ -282,12 +283,10 @@ acceptance_checks:
       and empty arguments. The LLM object never passes syntactically invalid
       JSON/YAML downstream.
 
-traceability:
+  traceability:
   requirements:
-    - prd001-tool-system-components-interfaces:R2.3
-    - prd004-tool-invocation-validation:R1.1
-    - prd004-tool-invocation-validation:R5.2
-    - prd004-tool-invocation-validation:R6.3
-    - prd004-tool-invocation-validation:R6.4
+    - prd006-stitch-essential-toolset:R2.1
+    - prd006-stitch-essential-toolset:R2.4
+    - prd004-tool-invocation-validation:R4.4
   use_cases:
-    - uc001-agentic-loop-core
+    - rel01.0-uc001-agentic-loop-core

--- a/docs/specs/interfaces/if002-agent-invoke-interface.yaml
+++ b/docs/specs/interfaces/if002-agent-invoke-interface.yaml
@@ -1,30 +1,33 @@
 id: if002-agent-invoke-interface
-title: Stitch Agent Invoke Interface Contract
+title: Engine Invoke Interface Contract
 component: StitchBoundaryAdapter
 
 purpose: |
-  Define the invocation interface used by the orchestrator to start a code
-  generation loop. The orchestrator creates an assignment crumb in its own
-  workflow trail, then calls invoke. The agent creates a loop trail with a
-  branches_from link to the assignment crumb, starts the loop in its own
-  goroutine, and returns the loop trail ID immediately.
+  Define the invocation interface used by the orchestrator to start the Engine.
+  The orchestrator creates an assignment crumb in its own workflow trail, then
+  calls invoke. The StitchBoundaryAdapter loads the Machine and tool declarations,
+  validates them, creates an execution trail with a branches_from link to the
+  assignment crumb, starts the Engine dispatch loop in its own goroutine, and
+  returns the execution trail ID immediately.
 
   The orchestrator does not block. It discovers progress and outcome by
-  querying the loop trail state and crumbs via the cupboard. When the trail
+  querying the execution trail state and crumbs via the cupboard. When the trail
   reaches completed or abandoned, the orchestrator reads the result crumb
-  (LoopResult from if010) to determine what happened.
+  (ExecutionResult with outcome classification) to determine what happened.
 
 ownership_boundary:
   orchestrator_responsibilities:
     - prepare_execution_environment
     - configure_allowed_tools_and_settings
     - create_assignment_crumb_in_workflow_trail
-    - poll_loop_trail_for_outcome
-  stitch_runtime_responsibilities:
+    - poll_execution_trail_for_outcome
+  runtime_responsibilities:
     - validate invoke request
-    - create loop trail with branches_from link
-    - start loop in goroutine
-    - write result crumb and transition trail on exit
+    - load Machine and tool declarations
+    - validate Machine against tool signal sets
+    - create execution trail with branches_from link
+    - start Engine dispatch loop in goroutine
+    - write result crumb and transition trail on terminal state
 
 types:
   AgentInvokeRequest:
@@ -89,19 +92,20 @@ types:
 
   AgentInvokeResponse:
     description: |
-      Returned immediately after the loop trail is created and the goroutine
-      is started. The orchestrator uses loop_trail_id to poll for outcome.
+      Returned immediately after the execution trail is created and the Engine
+      dispatch loop goroutine is started. The orchestrator uses execution_trail_id
+      to poll for outcome.
     required:
       - assignment_id
-      - loop_trail_id
+      - execution_trail_id
       - status
     fields:
       assignment_id:
         type: string
-      loop_trail_id:
+      execution_trail_id:
         type: string
         description: |
-          The trail ID of the loop trail. The orchestrator queries this
+          The trail ID of the execution trail. The orchestrator queries this
           trail in the cupboard to discover progress and outcome.
       status:
         type: string
@@ -109,7 +113,7 @@ types:
           - started
           - rejected
         description: |
-          started means the loop goroutine is running and the trail exists.
+          started means the Engine dispatch loop goroutine is running and the trail exists.
           rejected means validation failed and no trail was created.
       error:
         type: object
@@ -128,11 +132,12 @@ operations:
       - Validate the request (assignment_crumb_id exists, provider configured, tools valid).
       - On validation failure, return status=rejected with error.
       - Create a loop trail in the cupboard.
-      - Create a branches_from link from the loop trail to assignment_crumb_id.
-      - Create a token tracking stash scoped_to the loop trail.
+      - Create a branches_from link from the execution trail to assignment_crumb_id.
+      - Create a token tracking stash scoped_to the execution trail.
+      - Load Machine and tool declarations, validate Machine against tool signal sets.
       - Transition trail to active.
-      - Start the loop (if010 start_loop) in a new goroutine.
-      - Return immediately with status=started and the loop_trail_id.
+      - Start the Engine dispatch loop in a new goroutine.
+      - Return immediately with status=started and the execution_trail_id.
 
 error_codes:
   - assignment_crumb_not_found
@@ -169,4 +174,6 @@ traceability:
     - rel01.0-uc002-orchestrator-stitch-boundary
   architecture_components:
     - StitchBoundaryAdapter
-    - AgentLoopOrchestrator
+    - Engine
+    - Machine
+    - Registry

--- a/docs/specs/interfaces/if010-agent-loop-state-machine.yaml
+++ b/docs/specs/interfaces/if010-agent-loop-state-machine.yaml
@@ -1,26 +1,27 @@
 id: if010-agent-loop-state-machine
-title: Agent Loop State Machine
-component: AgentLoopOrchestrator
+title: Machine Data Structure
+component: Engine
 
 purpose: |
-  Define the state machine for the LLM-tool interaction loop that drives
-  code generation. The loop runs inside a trail that branches_from a crumb
-  in the orchestrator's workflow trail. Each turn consists of one LLM call
-  followed by execution of all returned tool calls. The loop terminates on
-  explicit conditions and reports its outcome via the trail state and a
-  result crumb.
+  Define the Machine data structure that the Engine interprets. The Machine is a
+  pure data structure mapping (state, signal) to (next_state, action) with no
+  logic, conditionals, or loops. States are inert markers of position. Signals are
+  typed tool outcomes. Transitions route signals to the next state and tool.
+  Terminal states halt execution with outcome classification.
 
-  The loop does not decide what to do about failures. It reports them.
-  The orchestrator reads the trail state and result crumb from the cupboard
-  and decides the next action (retry with different spec, break down work,
-  give up).
+  The Engine is a fixed dispatch loop that consults the Machine, resolves tools
+  through the Registry, calls Execute, records crumbs, and routes returned signals.
+  The Engine does not decide what to do about failures. It reports them via
+  outcome classification. The orchestrator reads the trail state and result crumb
+  from the cupboard and decides the next action.
 
 dependencies:
   - LLMToolAdapter
-  - ToolRegistry
+  - Registry
   - WorkspaceMutationPort
   - MessageHistory (if007)
   - CrumbLedger (if006)
+  - TracePort (prd027)
 
 types:
   LoopConfig:

--- a/docs/specs/product-requirements/prd001-tool-system-components-interfaces.yaml
+++ b/docs/specs/product-requirements/prd001-tool-system-components-interfaces.yaml
@@ -1,74 +1,81 @@
 id: prd001-tool-system-components-interfaces
-title: Tool System Components and Interfaces
+title: Engine, Machine, and Registry Components
 
 problem: |
-  We need a stable component contract for tool registration, selection, validation,
-  invocation, normalization, and eventing. Without explicit boundaries, implementations
-  diverge in behavior, safety, and observability.
+  We need a stable component contract for the declarative agent runtime. Without
+  explicit boundaries between the Engine (interpreter), Machine (transition
+  table), and Registry (tool resolution), implementations diverge in behavior,
+  safety, and observability. The imperative AgentLoopOrchestrator model buried
+  control flow in code; the declarative model makes control flow data that can be
+  validated, diffed, and replayed.
 
 goals:
-  - G1: Define canonical runtime components for tool execution control.
-  - G2: Define interface contracts that support multiple agent families.
-  - G3: Define component relationships and sequence responsibilities.
+  - G1: Define the Engine as a fixed dispatch loop that interprets the Machine.
+  - G2: Define the Machine as a pure data structure mapping (state, signal) to (next_state, action).
+  - G3: Define the Registry as the tool resolution layer with static validation.
   - G4: Define testable acceptance criteria with complete requirement traceability.
 
 requirements:
   R1:
-    title: Component Boundaries
+    title: Engine
     items:
-    - R1.1: Runtime must define ToolRegistry, ToolSelector, ToolCallInterpreter, ToolSyntaxValidator, ToolSemanticValidator, PermissionGate, ToolInvoker, ResultNormalizer, and ToolEventBus.
-    - R1.2: Each component must have one primary responsibility and explicit input and output contract.
-    - R1.3: Component contracts must be independent from provider-specific SDK internals.
+    - R1.1: Runtime must define Engine as a fixed dispatch loop that consults the Machine, resolves tools through the Registry, calls Execute, records crumbs, and routes returned signals.
+    - R1.2: Engine must hold no domain logic. If conditionals accumulate in the Engine, they belong in a tool or the Machine.
+    - R1.3: Engine must expose four operations: Run, Resume, Rollback, and History.
+    - R1.4: Engine must classify execution outcome on terminal state (Clean, Recovery, Stuck, Divergent).
   R2:
-    title: Data Contracts
+    title: Machine
     items:
-    - R2.1: Runtime must define ToolDescriptor contract with tool identity, schemas, capability tags, and adapter key.
-    - R2.2: Runtime must define SelectionContext contract including trail, phase, permission mode, and feature flags.
-    - R2.3: Runtime must define canonical ToolCall and ToolResult contracts for all invocation paths.
+    - R2.1: Runtime must define Machine as a pure data structure mapping (state, signal) to (next_state, action) with no logic, conditionals, or loops.
+    - R2.2: Machine must declare initial_state, terminal_states, and transitions.
+    - R2.3: Machine must support $tool slots for dynamic dispatch where the model selects the tool at runtime.
+    - R2.4: Machine must be loadable, serializable, and validatable without executing code.
   R3:
-    title: Interface Contracts
+    title: Registry
     items:
-    - R3.1: Runtime must define registry and selector interfaces for tool discovery and effective set projection.
-    - R3.2: Runtime must define interpreter and validator interfaces for shape and semantic checks.
-    - R3.3: Runtime must define permission, invoker, and normalizer interfaces for execution and outcome packaging.
+    - R3.1: Runtime must define Registry as the tool resolution layer that maps tool names to implementations at load time.
+    - R3.2: Registry must hold tool declarations with parameter types, signal sets, undo modes, and side effects.
+    - R3.3: Registry must support factory dispatch for tool construction (exec, rest, builtin, boundary).
+    - R3.4: Registry must validate that every tool name referenced in the Machine has a declaration.
   R4:
-    title: Relationship and Sequence Model
+    title: Static Validation
     items:
-    - R4.1: Runtime must define structural relationships between components.
-    - R4.2: Runtime must define ordered sequence from selection through normalization.
-    - R4.3: Invocation must be blocked unless validation and permission checks pass.
+    - R4.1: Engine must validate the Machine at load time before any tool executes.
+    - R4.2: Validation must check that every state-signal pair in the Machine has a transition.
+    - R4.3: Validation must check that every signal a tool emits is handled in every state where the tool can be dispatched.
+    - R4.4: Validation must reject unhandled signals as load-time errors.
   R5:
-    title: Observability and Audit
+    title: Execution Recording
     items:
-    - R5.1: Runtime must emit lifecycle events for selection, validation, permission decisions, invocation, and normalization.
-    - R5.2: Events must be correlated by call and trail identifiers.
-    - R5.3: Denied and failed calls must be represented in normalized results.
+    - R5.1: Engine must record each dispatch cycle as a crumb with state, signal, tool, and result metadata.
+    - R5.2: Crumbs must be correlated by trail id and execution id.
+    - R5.3: The execution record must reconstruct without re-running any tool.
 non_goals:
   - Define provider-specific prompt payload formats.
   - Define individual tool business logic internals.
   - Define rollout sequencing for production deployment.
 
 semantic_model:
-  observe: "Tool call intents from the LLM, stash entries for the active trail, and tool descriptors from the registry"
-  reason: "Resolve the effective tool set from stash, normalize calls into canonical ToolCall contracts, validate availability and semantics in ordered stages, and route execution outcomes to crumb persistence or next invocation"
-  produce: "Canonical ToolCall records, validation outcomes with stage-specific rejection reasons, invocation crumbs with correlated trail and call ids, and lifecycle events for selection, validation, permission, and execution edges"
+  observe: "Machine transition table (states, signals, transitions), Registry tool declarations (parameter types, signal sets, undo modes), and execution trail crumbs"
+  reason: "Validate the Machine against tool signal sets at load time, enter the initial state, and run the dispatch cycle: look up (state, signal) in the Machine, resolve the tool through the Registry, call Execute, record the crumb, and route the returned signal to the next transition until a terminal state is reached"
+  produce: "Execution trail crumbs with state, signal, tool, and result metadata per dispatch cycle, outcome classification (Clean, Recovery, Stuck, Divergent) on terminal state, and a replayable execution record"
 
 acceptance_criteria:
   - id: AC1
-    criterion: Canonical component list and responsibility descriptions exist and are unambiguous.
-    traces: [R1.1, R1.2]
+    criterion: Engine is defined as a fixed dispatch loop with Run, Resume, Rollback, and History operations and no domain logic.
+    traces: [R1.1, R1.2, R1.3]
   - id: AC2
-    criterion: Data contracts for ToolDescriptor, SelectionContext, ToolCall, and ToolResult are specified with required fields.
-    traces: [R2.1, R2.2, R2.3]
+    criterion: Engine classifies execution outcome on terminal state into Clean, Recovery, Stuck, or Divergent.
+    traces: [R1.4]
   - id: AC3
-    criterion: Registry, selector, interpreter, validators, permission, invoker, and normalizer interfaces are specified.
-    traces: [R3.1, R3.2, R3.3]
+    criterion: Machine is defined as a pure data structure with initial_state, terminal_states, transitions, and $tool dynamic dispatch support.
+    traces: [R2.1, R2.2, R2.3, R2.4]
   - id: AC4
-    criterion: Structural and sequence relationship definitions show blocked invocation when validation or permission fails.
-    traces: [R4.1, R4.2, R4.3]
+    criterion: Registry resolves tool names to implementations, holds tool declarations, and supports factory dispatch.
+    traces: [R3.1, R3.2, R3.3, R3.4]
   - id: AC5
-    criterion: Lifecycle event requirements and correlation requirements are specified for all decision edges.
-    traces: [R5.1, R5.2, R5.3]
+    criterion: Static validation checks state-signal pair completeness, signal handling per dispatchable state, and rejects unhandled signals at load time.
+    traces: [R4.1, R4.2, R4.3, R4.4]
   - id: AC6
-    criterion: Component and interface definitions remain provider-agnostic.
-    traces: [R1.3]
+    criterion: Execution recording produces correlated crumbs with state, signal, tool, and result metadata that reconstruct without re-running tools.
+    traces: [R5.1, R5.2, R5.3]

--- a/docs/specs/product-requirements/prd002-trail-lifecycle-state-machine.yaml
+++ b/docs/specs/product-requirements/prd002-trail-lifecycle-state-machine.yaml
@@ -1,84 +1,80 @@
 id: prd002-trail-lifecycle-state-machine
-title: Trail Lifecycle State Machine
+title: Machine State Lifecycle
 
 problem: |
-  Tool execution contracts exist, but orchestration remains undefined without a trail state machine.
-  We need deterministic lifecycle transitions, guard checks, and transition events for trail-level
-  control and audit.
+  The Machine defines the agent's control flow as a transition table. Without
+  explicit state lifecycle rules, the Machine cannot be validated, replayed, or
+  resumed. States must be inert markers of position with no behavior. Transitions
+  must be deterministic lookup entries, not code paths. Terminal states must halt
+  execution with a typed outcome.
 
 goals:
-  - G1: Define trail states and legal transitions.
-  - G2: Define transition guards for activation, completion, and abandonment.
-  - G3: Define lifecycle event contracts for observability.
-  - G4: Define interaction points with rollback flow.
+  - G1: Define Machine states and legal transitions as data.
+  - G2: Define signal-based transition routing with closed-world validation.
+  - G3: Define terminal states and outcome classification.
+  - G4: Define execution trail lifecycle for resumption and rollback.
 
 requirements:
   R1:
     title: State Model
     items:
-    - R1.1: Trail states must include draft, active, completed, and abandoned.
-    - R1.2: Each trail must have exactly one current state.
-    - R1.3: State transitions must persist atomically with transition metadata.
+    - R1.1: Machine states must be inert markers of position identified by name, carrying no behavior.
+    - R1.2: Machine must declare exactly one initial_state.
+    - R1.3: Machine must declare one or more terminal_states that halt execution.
+    - R1.4: Terminal states must be classified as successful or failed for outcome reporting.
   R2:
-    title: Legal Transitions
+    title: Transitions
     items:
-    - R2.1: Transition draft to active must be allowed.
-    - R2.2: Transition active to completed must be allowed.
-    - R2.3: Transition active to abandoned must be allowed.
-    - R2.4: Transitions from terminal states must be rejected.
+    - R2.1: Transitions must map (state, signal) to (next_state, action) as pure data entries.
+    - R2.2: Each transition must specify the tool name to dispatch or $tool for dynamic dispatch.
+    - R2.3: Transitions to terminal states must omit the action field.
+    - R2.4: The Machine must handle every signal every tool can emit in every state where the tool can be dispatched.
   R3:
-    title: Activation Guards
+    title: Signal Routing
     items:
-    - R3.1: Activation must require a resolvable trail-bound stash.
-    - R3.2: Activation must fail when stash resolution fails.
-    - R3.3: Activation must persist stash id and stash version in trail metadata.
+    - R3.1: Signals must be typed tool outcomes used as transition lookup keys.
+    - R3.2: Each tool must declare a finite, closed set of signals it can emit.
+    - R3.3: Unhandled signals must be rejected as load-time errors before execution.
+    - R3.4: The Engine must route signals to transitions without ad hoc classification.
   R4:
-    title: Completion and Abandon Guards
+    title: Execution Trail Lifecycle
     items:
-    - R4.1: Completion must require no unresolved blocking failures.
-    - R4.2: Abandon must be allowed when unresolved failures exist.
-    - R4.3: Abandon may trigger rollback plan execution when configured.
+    - R4.1: Each execution must create a trail with a branches_from link to the orchestrator assignment crumb.
+    - R4.2: Trail state must transition through draft, active, completed, or abandoned.
+    - R4.3: Terminal state must set the trail to completed (success) or abandoned (failure).
+    - R4.4: Trail state must persist atomically with transition metadata.
   R5:
-    title: Eventing and Audit
+    title: Resumption and Replay
     items:
-    - R5.1: Successful transitions must emit lifecycle events.
-    - R5.2: Rejected transitions must emit rejection events with reason code.
-    - R5.3: Transition events must include trail id, from state, to state, actor, and timestamp.
-  R6:
-    title: Crumb Relationship
-    items:
-    - R6.1: Every crumb must reference one trail.
-    - R6.2: Completed trails must reject new crumbs.
-    - R6.3: Abandoned trails must reject new crumbs.
+    - R5.1: Engine position must reduce to two values: current state and last signal.
+    - R5.2: Execution must be serializable after any tool completes and resumable from the serialized checkpoint.
+    - R5.3: The execution record must reconstruct the full path without re-running any tool.
 non_goals:
-  - Define tool argument semantics.
-  - Define per-tool permission internals.
+  - Define tool implementation internals.
+  - Define provider-specific signal mapping.
   - Define low-level persistence implementation choices.
 
 semantic_model:
-  observe: "Trail state transition requests, stash resolution results for activation guards, and blocking failure counts for completion guards"
-  reason: "Validate transition legality against the state model (draft, active, completed, abandoned), enforce activation guards requiring a resolvable stash, enforce completion guards requiring no unresolved failures, and reject transitions from terminal states"
-  produce: "Atomically persisted state transitions with metadata, lifecycle events with trail id and timestamp, rejection events with reason codes, and crumb acceptance or rejection based on trail state"
+  observe: "Machine transition table (states, signals, transitions, terminal states), tool signal declarations from the Registry, and execution trail state"
+  reason: "Validate that every state-signal pair has a transition and every tool signal is handled, enter the initial state, route signals to transitions via lookup, and halt when a terminal state is reached with outcome classification"
+  produce: "Validated Machine ready for execution, execution trail with state transitions and crumb records, and terminal state outcome (Clean, Recovery, Stuck, Divergent) for orchestrator recovery decisions"
 
 acceptance_criteria:
   - id: AC1
-    criterion: Trail state set supports only draft, active, completed, and abandoned with one active state at a time.
-    traces: [R1.1, R1.2]
+    criterion: Machine states are inert markers with one initial_state and one or more terminal_states classified as successful or failed.
+    traces: [R1.1, R1.2, R1.3, R1.4]
   - id: AC2
-    criterion: Legal transitions draft to active, active to completed, and active to abandoned are accepted.
+    criterion: Transitions map (state, signal) to (next_state, action) as data entries with $tool dynamic dispatch support and terminal transitions omit actions.
     traces: [R2.1, R2.2, R2.3]
   - id: AC3
-    criterion: Transitions from terminal states are rejected with structured reason events.
-    traces: [R2.4, R5.2]
+    criterion: Every signal every tool can emit is handled in every dispatchable state, with unhandled signals rejected at load time.
+    traces: [R2.4, R3.1, R3.2, R3.3]
   - id: AC4
-    criterion: Activation fails when stash cannot be resolved and succeeds when stash id and version are persisted.
-    traces: [R3.1, R3.2, R3.3]
+    criterion: Engine routes signals to transitions via lookup with no ad hoc classification.
+    traces: [R3.4]
   - id: AC5
-    criterion: Completion and abandon guard behavior is enforced, including optional rollback trigger on abandon.
-    traces: [R4.1, R4.2, R4.3]
+    criterion: Execution trail lifecycle transitions through draft, active, completed, or abandoned with atomic persistence.
+    traces: [R4.1, R4.2, R4.3, R4.4]
   - id: AC6
-    criterion: Transition writes are atomic and include complete transition metadata.
-    traces: [R1.3, R5.1, R5.3]
-  - id: AC7
-    criterion: Crumb creation requires trail linkage and is rejected for completed or abandoned trails.
-    traces: [R6.1, R6.2, R6.3]
+    criterion: Engine position reduces to (current state, last signal), is serializable, and the execution record reconstructs without re-running tools.
+    traces: [R5.1, R5.2, R5.3]

--- a/docs/specs/product-requirements/prd003-tool-stash-availability.yaml
+++ b/docs/specs/product-requirements/prd003-tool-stash-availability.yaml
@@ -1,82 +1,78 @@
 id: prd003-tool-stash-availability
-title: Tool Stash Availability
+title: Scoped Toolset and Per-State Tool Availability
 
 problem: |
-  Model-proposed tool calls must be constrained by workflow context. Without stash-gated
-  eligibility, tools can execute outside intended capability boundaries.
+  Agents accumulate tools — file manipulation, shell, build, lint, search — and
+  sending the full manifest to the model in every state wastes decision bandwidth
+  and enables phase-inappropriate use. Without per-state tool scoping, a
+  destructive tool can fire in a phase where it is premature, and the model must
+  evaluate and reject every tool in every turn. The trail-scoped stash is too
+  coarse: it allows all stash tools in all states, violating workflow invariants.
 
 goals:
-  - G1: Define stash as per-trail tool availability authority.
-  - G2: Define deterministic eligibility resolution.
-  - G3: Support policy-safe overrides.
-  - G4: Define auditable availability decisions.
+  - G1: Define per-state tool availability driven by the Machine.
+  - G2: Define manifest filtering before each LLM invocation.
+  - G3: Support deny-by-default with explicit per-state visibility lists.
+  - G4: Define auditable availability decisions with manifest validation.
 
 requirements:
   R1:
-    title: Stash Data Model
+    title: Per-State Tool Visibility
     items:
-    - R1.1: Stash must include stash_id, version, and entries.
-    - R1.2: Each stash entry must include tool_name and enabled.
-    - R1.3: Each stash entry may include policy mode and default args.
-    - R1.4: Stash schema must support YAML and JSON serialization.
+    - R1.1: Machine must declare, per non-terminal state, the list of tool names visible to the model.
+    - R1.2: Tools absent from the current state's visibility list must be invisible to the model.
+    - R1.3: Machine-dispatched tools (fixed actions like parse_response) must not appear in the manifest.
+    - R1.4: Each tool declaration must include a visibility field (external for manifest-eligible, internal for machine-dispatched only).
   R2:
-    title: Trail Binding
+    title: Manifest Filtering
     items:
-    - R2.1: Active trail must reference exactly one active stash.
-    - R2.2: Activation must fail if referenced stash does not exist.
-    - R2.3: Activation must persist stash version in trail metadata.
-    - R2.4: Runtime must support configurable stash mutability policy for active trails.
+    - R2.1: PromptAssembler must query the Machine for the current state's visible tools before each LLM invocation.
+    - R2.2: PromptAssembler must resolve each visible tool name against the Registry and build a filtered ToolManifest.
+    - R2.3: Unresolved tool names in the visibility list must be load-time errors.
+    - R2.4: The filtered manifest must be sent with the prompt, not the full Registry.
   R3:
-    title: Eligibility Resolution
+    title: Manifest Validation
     items:
-    - R3.1: Availability check must run before argument decoding.
-    - R3.2: Tool is eligible only when entry exists and enabled is true.
-    - R3.3: Unavailable tools must be rejected with reason code tool_not_in_stash.
-    - R3.4: Availability decisions must include trail id, stash id, stash version, and tool name.
+    - R3.1: Tools returned by the model must be validated against the manifest the model was shown.
+    - R3.2: Hallucinated tool names (not in the manifest) must be rejected before dispatch.
+    - R3.3: The static check (is the tool registered and its signals handled in this state) must run after manifest validation.
+    - R3.4: Manifest validation and static check failures must emit rejection crumbs with reason codes.
   R4:
-    title: Policy Overrides
+    title: Stash as Per-State Scoping Mechanism
     items:
-    - R4.1: Stash entry may define per-tool policy mode for downstream permission behavior.
-    - R4.2: Stash defaults may merge into call args only when descriptor allows defaults.
-    - R4.3: Policy overrides must never enable tools absent from stash entries.
+    - R4.1: The stash concept survives as the mechanism for per-state tool scoping, binding tool availability to Machine state.
+    - R4.2: Stash entries must include tool name, enabled flag, and visibility classification.
+    - R4.3: Stash schema must support YAML and JSON serialization.
+    - R4.4: Stash must be resolvable per state at load time for static validation.
   R5:
     title: Observability and Audit
     items:
-    - R5.1: Every availability decision must emit an event.
-    - R5.2: Rejected availability decisions must create rejection crumbs.
-    - R5.3: Decision events must include call and trail correlation ids.
+    - R5.1: Every manifest filtering decision must be recorded with state, visible tools, and manifest size.
+    - R5.2: Rejected tool calls (hallucinated or out-of-scope) must create rejection crumbs.
+    - R5.3: Manifest events must include trail id, state, and tool correlation ids.
 non_goals:
   - Define tool semantic validation internals.
   - Define runtime permission enforcement internals.
   - Define rollback execution internals.
 
 semantic_model:
-  observe: "Stash entries for the active trail, tool names from incoming call intents, and stash version from trail metadata"
-  reason: "Resolve the active stash for the trail, check whether the requested tool has an entry with enabled set to true, and deny-by-default when no entry exists"
-  produce: "Eligibility decisions with trail, stash, and tool correlation ids, rejection crumbs for unavailable tools with reason tool_not_in_stash, and availability events for every decision"
+  observe: "Machine per-state tool visibility lists, Registry tool declarations with visibility classification, and model-returned tool call names"
+  reason: "Query the Machine for the current state's visible tools, resolve each against the Registry, build a filtered manifest, validate model-returned tool names against the manifest, and reject hallucinated or out-of-scope tools before dispatch"
+  produce: "Filtered ToolManifest per LLM invocation, rejection crumbs for out-of-scope tool calls with reason codes, and manifest events with state and tool correlation"
 
 acceptance_criteria:
   - id: AC1
-    criterion: Trail activation fails for missing stash and succeeds for existing stash.
-    traces: [R2.1, R2.2]
+    criterion: Machine declares per-state tool visibility lists with external/internal classification, and tools absent from the current state are invisible.
+    traces: [R1.1, R1.2, R1.3, R1.4]
   - id: AC2
-    criterion: Calls to tools absent from stash are rejected before decode with reason tool_not_in_stash.
-    traces: [R3.1, R3.2, R3.3]
+    criterion: PromptAssembler queries the Machine, resolves visible tools against the Registry, and builds a filtered manifest before each LLM invocation.
+    traces: [R2.1, R2.2, R2.3, R2.4]
   - id: AC3
-    criterion: Availability decisions persist trail, stash, stash version, and tool context.
-    traces: [R3.4, R5.3]
+    criterion: Model-returned tool names are validated against the manifest, hallucinated names are rejected, and static signal handling checks run after manifest validation.
+    traces: [R3.1, R3.2, R3.3, R3.4]
   - id: AC4
-    criterion: Rejection path emits event and writes rejection crumb.
-    traces: [R5.1, R5.2]
+    criterion: Stash binds tool availability to Machine state with YAML/JSON serialization and load-time resolution.
+    traces: [R4.1, R4.2, R4.3, R4.4]
   - id: AC5
-    criterion: Stash schema round-trips in YAML and JSON.
-    traces: [R1.4]
-  - id: AC6
-    criterion: Stash schema enforces required top-level and entry fields, and accepts optional policy and defaults fields.
-    traces: [R1.1, R1.2, R1.3]
-  - id: AC7
-    criterion: Activation persists stash version and enforces configured mutability behavior.
-    traces: [R2.3, R2.4]
-  - id: AC8
-    criterion: Policy overrides and defaults never enable missing tools.
-    traces: [R4.1, R4.2, R4.3]
+    criterion: Manifest filtering decisions and rejections are recorded with state, tool, and trail correlation.
+    traces: [R5.1, R5.2, R5.3]

--- a/docs/specs/product-requirements/prd004-tool-invocation-validation.yaml
+++ b/docs/specs/product-requirements/prd004-tool-invocation-validation.yaml
@@ -1,90 +1,83 @@
 id: prd004-tool-invocation-validation
-title: Tool Invocation and Validation
+title: Tool Contract Validation
 
 problem: |
-  Model output cannot be executed directly. We need a strict runtime pipeline that normalizes
-  call formats, validates availability and arguments, enforces semantic checks, executes safely,
-  and records deterministic outcomes.
+  Tools must be typed contracts, not function signatures with docstrings. Without
+  declared parameter types, emittable signals, undo modes, and side effects, the
+  Machine cannot be statically validated, the Engine cannot dispatch tools
+  generically, and rollback cannot reverse operations from the declaration alone.
+  The imperative validation pipeline (availability, decode, semantic) must be
+  replaced by Tool Contract validation at load time and signal-based dispatch at
+  runtime.
 
 goals:
-  - G1: Define canonical tool call pipeline for all source formats.
-  - G2: Enforce typed decoding before execution.
-  - G3: Enforce tool-owned semantic validation.
-  - G4: Normalize execution outcomes into auditable crumb records.
+  - G1: Define Tool Contract as the typed specification behind each tool.
+  - G2: Enforce static Machine validation against tool signal sets at load time.
+  - G3: Define tool execution and undo as the two mandatory operations.
+  - G4: Normalize tool outcomes into typed signals for Machine routing.
 
 requirements:
   R1:
-    title: Canonical ToolCall
+    title: Tool Contract Structure
     items:
-    - R1.1: Runtime must normalize all incoming call formats into one ToolCall contract.
-    - R1.2: Canonical ToolCall must include call id, trail id, tool name, and raw args.
+    - R1.1: Each tool must declare a contract with parameter types, emittable signals, undo mode, and side effects.
+    - R1.2: Each tool must do exactly one thing. If a tool needs "and" to describe it, it is two tools.
+    - R1.3: Tool contracts must be YAML declarations loadable and validatable without executing code.
+    - R1.4: Tool contracts must specify reversibility (none, reversible, compensating, snapshot).
   R2:
-    title: Validation Order
+    title: Static Validation
     items:
-    - R2.1: Availability validation must execute first.
-    - R2.2: Structural and decode validation must execute second.
-    - R2.3: Semantic validation must execute third.
-    - R2.4: Invocation must run only if prior stages pass.
+    - R2.1: ToolContractValidator must verify every tool name referenced in the Machine has a declaration in the Registry.
+    - R2.2: ToolContractValidator must verify every signal a tool declares to emit is handled in every state where the tool can be dispatched.
+    - R2.3: ToolContractValidator must verify parameter types match between tool declarations and Machine references.
+    - R2.4: Validation must run at load time before any tool executes, rejecting unhandled signals as errors.
   R3:
-    title: Typed Decoding
+    title: Tool Execution
     items:
-    - R3.1: Runtime must decode raw args into typed Go structs.
-    - R3.2: Decode failures must return structured validation outcomes.
-    - R3.3: Decode layer must support JSON and YAML payloads.
+    - R3.1: Each tool must implement Execute (perform the operation and return a typed signal) and Undo (reverse the operation given the recorded result).
+    - R3.2: Execute must accept typed parameters and return a ToolResult with signal, output, and undo metadata.
+    - R3.3: Read-only tools must make Undo a no-op.
+    - R3.4: Tools must fail loudly with an error signal carrying enough information to route recovery.
   R4:
-    title: Semantic Validation
+    title: Signal Declaration
     items:
-    - R4.1: Every executable tool must expose semantic validator entrypoint.
-    - R4.2: Semantic validator must receive typed args and execution context.
-    - R4.3: Semantic validation failures must block invocation and write rejection crumbs.
+    - R4.1: Each tool must declare a finite, closed set of signals it can emit.
+    - R4.2: The Machine must handle every signal in the set.
+    - R4.3: Signals must be typed outcomes used as transition lookup keys.
+    - R4.4: Boundary tools (invoke_llm, serve_ui, run_agent) must declare their variance explicitly through signal sets.
   R5:
-    title: Execution and Error Policy
+    title: Tool Categories
     items:
-    - R5.1: Initial permission behavior must follow execute-and-report.
-    - R5.2: OS and runtime failures must be reported as structured execution errors.
-    - R5.3: Runtime must never synthesize success for failed calls.
-  R6:
-    title: Recording and Events
-    items:
-    - R6.1: Every invocation attempt must create one primary crumb.
-    - R6.2: Rejected calls must include stage outcome metadata in crumbs.
-    - R6.3: Successful calls must include result metadata and duration.
-    - R6.4: Validation and execution events must share call correlation id.
+    - R5.1: Tools must be categorized as deterministic (same signal given identical inputs) or boundary (crosses to external actor with unpredictable response).
+    - R5.2: Boundary tools must be the primary source of variance declared in the Machine.
+    - R5.3: Non-terminal tools must run an entire sub-machine and return a single signal to the parent machine.
+    - R5.4: Composite tools (multiple operations in one interface) must be rejected as anti-patterns and decomposed.
 non_goals:
   - Define stash schema lifecycle.
   - Define long-horizon planner behavior.
   - Define rollback plan execution details.
 
 semantic_model:
-  observe: "Incoming ToolCallIntent objects with parsed JSON arguments, stash eligibility results, and typed decode targets from tool descriptors"
-  reason: "Execute the validation pipeline in order (availability, structural decode, semantic validation), block invocation on any stage failure, and map OS and runtime failures to structured execution errors without synthesizing success"
-  produce: "Canonical ToolCall records with call id and trail id, structured validation outcomes per stage, invocation crumbs with result metadata and duration, and correlated events sharing call correlation id across all stages"
+  observe: "Tool declarations (parameter types, signal sets, undo modes, side effects), Machine transition table, and Registry tool name resolution"
+  reason: "Validate every tool reference and signal at load time, categorize tools as deterministic or boundary, reject composite tools, and verify that Execute and Undo are present for every tool"
+  produce: "Validated tool contracts ready for Engine dispatch, typed signals for Machine routing, and undo metadata for Engine-driven rollback"
 
 acceptance_criteria:
   - id: AC1
-    criterion: Malformed args fail in decode stage and do not execute.
-    traces: [R2.2, R3.1, R3.2]
+    criterion: Each tool declares a contract with parameter types, emittable signals, undo mode, and side effects as YAML.
+    traces: [R1.1, R1.2, R1.3, R1.4]
   - id: AC2
-    criterion: Semantic failures block invocation and produce rejection crumbs.
-    traces: [R2.3, R4.3, R6.2]
-  - id: AC3
-    criterion: Permission and OS failures are reported as execution errors and persisted.
-    traces: [R5.1, R5.2, R6.1]
-  - id: AC4
-    criterion: Successful calls persist duration and correlated result metadata.
-    traces: [R6.3, R6.4]
-  - id: AC5
-    criterion: Validation order is enforced as availability, decode, semantic, and invoke.
+    criterion: ToolContractValidator verifies tool name resolution, signal handling per dispatchable state, and parameter type matching at load time.
     traces: [R2.1, R2.2, R2.3, R2.4]
+  - id: AC3
+    criterion: Each tool implements Execute (returns typed signal) and Undo (reverses with recorded result), with read-only tools making Undo a no-op.
+    traces: [R3.1, R3.2, R3.3]
+  - id: AC4
+    criterion: Tools fail loudly with error signals carrying recovery-routing information.
+    traces: [R3.4]
+  - id: AC5
+    criterion: Each tool declares a closed signal set handled by the Machine, with boundary tools declaring variance explicitly.
+    traces: [R4.1, R4.2, R4.3, R4.4]
   - id: AC6
-    criterion: Native and parsed sources normalize to canonical ToolCall fields.
-    traces: [R1.1, R1.2]
-  - id: AC7
-    criterion: YAML decode behavior matches JSON decode behavior for typed structs.
-    traces: [R3.3]
-  - id: AC8
-    criterion: Semantic validator contract is present and receives typed args plus context.
-    traces: [R4.1, R4.2]
-  - id: AC9
-    criterion: Failed invocation paths never produce success status.
-    traces: [R5.3]
+    criterion: Tools are categorized as deterministic or boundary, non-terminal tools compose sub-machines, and composite tools are rejected.
+    traces: [R5.1, R5.2, R5.3, R5.4]

--- a/docs/specs/product-requirements/prd005-undo-and-compensation.yaml
+++ b/docs/specs/product-requirements/prd005-undo-and-compensation.yaml
@@ -1,81 +1,79 @@
 id: prd005-undo-and-compensation
-title: Undo and Compensation
+title: Execution Rollback and Per-Tool Undo
 
 problem: |
-  Tool calls can produce side effects that must be reversed when a trail is abandoned or a
-  recovery flow is requested. Because tools vary in reversibility, undo behavior must be explicit,
-  mode-aware, and auditable.
+  Tool dispatches produce side effects that must be reversed when an execution is
+  abandoned or a recovery flow is requested. The imperative UndoManager with
+  declared undo modes was close in intent, but rollback must be an Engine
+  operation that walks the recorded execution backward, calling each tool's Undo
+  method with its recorded result. The execution record is a bidirectional log,
+  not an append-only log. Undo mode is a Tool Contract field, not a separate
+  descriptor property.
 
 goals:
-  - G1: Define explicit undo modes per tool.
-  - G2: Define deterministic reverse-order rollback planning and execution.
-  - G3: Define complete reporting for partial rollback outcomes.
-  - G4: Keep contracts safe for non-reversible tool classes.
+  - G1: Define per-tool Undo as the reversal mechanism, declared in the Tool Contract.
+  - G2: Define Engine-driven rollback that walks execution backward via recorded crumbs.
+  - G3: Define the rollback lifecycle machine as a separate, minimal machine.
+  - G4: Define complete reporting for partial rollback with irreversible tool handling.
 
 requirements:
   R1:
-    title: Undo Modes
+    title: Per-Tool Undo
     items:
-    - R1.1: Each tool descriptor must declare undo mode.
-    - R1.2: Supported undo modes must be none, reversible, compensating, and snapshot.
-    - R1.3: Runtime must reject undo requests requiring unsupported mode behavior.
+    - R1.1: Each tool must implement Undo as the reversal operation, receiving the recorded result from Execute.
+    - R1.2: Read-only tools must make Undo a no-op (Noop tier).
+    - R1.3: Undo mode (none, reversible, compensating, snapshot) must be declared in the Tool Contract, not a separate descriptor.
+    - R1.4: Tools must write UndoMemento during Execute carrying enough to reverse the effect without the original object.
   R2:
-    title: Undo Metadata Capture
+    title: Engine-Driven Rollback
     items:
-    - R2.1: Invocation crumbs must store undo token for reversible, compensating, and snapshot modes.
-    - R2.2: Snapshot mode must persist before-state references sufficient for restore.
-    - R2.3: Crumbs without undo metadata must remain visible as non-reversible during rollback.
+    - R2.1: Engine must walk the execution backward via recorded crumbs in reverse chronological order.
+    - R2.2: Engine must call Undo on each tool with its recorded UndoMemento.
+    - R2.3: Engine must continue rollback on step failure unless fail-fast is requested.
+    - R2.4: Rollback must restore three state layers: agent state (engine position), domain state (accumulated product), and workspace state (external world).
   R3:
-    title: Plan Construction
+    title: Rollback Lifecycle Machine
     items:
-    - R3.1: Undo plans must be constructed from crumbs in reverse chronological order.
-    - R3.2: Undo plans must include only crumbs within requested trail and range.
-    - R3.3: Undo plan steps must include mode and precondition metadata.
+    - R3.1: Rollback must run as its own finite-state machine, separate from the domain Machine.
+    - R3.2: The lifecycle machine must walk the execution backward, undoing reversible tools, skipping irreversible ones, and restoring from checkpoints.
+    - R3.3: The lifecycle machine must never dispatch a domain tool — it reads execution and checkpoints only.
+    - R3.4: Different rollback strategies must be implementable as different lifecycle machines.
   R4:
-    title: Undo Execution
+    title: Undo Tiers
     items:
-    - R4.1: UndoManager must execute undo actions in reverse order.
-    - R4.2: Each undo step must produce an undo result record.
-    - R4.3: Undo execution must preserve idempotency where tool contracts support idempotent undo.
-    - R4.4: Undo execution must continue on step failure unless fail-fast is requested.
+    - R4.1: Reversible tools must restore original state exactly via Undo.
+    - R4.2: Compensatable tools must issue a corrective action and log semantic differences.
+    - R4.3: Irreversible tools must be skipped and logged with tool, iteration, and reason.
+    - R4.4: Per-entry tier classification must allow mixed tiers within a single rollback.
   R5:
     title: Reporting and Audit
     items:
-    - R5.1: Undo summary must include success, failed, skipped, and non-reversible counts.
+    - R5.1: Rollback summary must include success, failed, skipped, and non-reversible counts.
     - R5.2: Undo steps must be persisted as undo crumbs linked to original crumbs.
-    - R5.3: Undo summary must include unresolved side effects.
+    - R5.3: Rollback summary must include unresolved side effects from irreversible tools.
 non_goals:
   - Guarantee full rollback for all tool classes.
   - Implement distributed transaction semantics across external systems.
-  - Redefine primary invocation validation flow.
+  - Redefine primary tool execution flow.
 
 semantic_model:
-  observe: "Invocation crumbs with undo metadata and declared undo modes, trail scope and range for rollback requests, and undo tokens from reversible, compensating, and snapshot modes"
-  reason: "Construct undo plans in reverse chronological order from crumbs within the requested trail, classify crumbs by undo mode (none, reversible, compensating, snapshot), and execute undo actions continuing on step failure unless fail-fast is requested"
-  produce: "Undo plan steps with mode and precondition metadata, per-step undo crumbs linked to original crumbs, and undo summaries with success, failed, skipped, non-reversible counts plus unresolved side-effect reports"
+  observe: "Recorded execution crumbs with UndoMemento payloads, Tool Contract undo mode declarations (none, reversible, compensating, snapshot), and checkpoint snapshots of agent, domain, and workspace state"
+  reason: "Walk the execution backward via recorded crumbs, classify each entry by undo tier, call Undo on reversible and compensatable tools with their UndoMemento, skip and log irreversible tools, and restore from checkpoints when boundaries are reached"
+  produce: "Undo crumbs linked to original crumbs, rollback summary with success, failed, skipped, and non-reversible counts, and unresolved side-effect reports for irreversible tools"
 
 acceptance_criteria:
   - id: AC1
-    criterion: Undo plans are generated in reverse order with mode annotations.
-    traces: [R3.1, R3.2, R3.3]
+    criterion: Each tool implements Undo with recorded UndoMemento, read-only tools make Undo a no-op, and undo mode is declared in the Tool Contract.
+    traces: [R1.1, R1.2, R1.3, R1.4]
   - id: AC2
-    criterion: Tools in none mode are reported as non-reversible and not invoked for undo.
-    traces: [R1.2, R1.3, R5.1]
+    criterion: Engine walks execution backward via crumbs, calls Undo per tool, continues on failure unless fail-fast, and restores agent, domain, and workspace state.
+    traces: [R2.1, R2.2, R2.3, R2.4]
   - id: AC3
-    criterion: Undo execution writes per-step undo crumbs linked to original crumbs.
-    traces: [R4.2, R5.2]
+    criterion: Rollback runs as a separate lifecycle machine that never dispatches domain tools and supports different rollback strategies.
+    traces: [R3.1, R3.2, R3.3, R3.4]
   - id: AC4
-    criterion: Undo summary includes success, failure, skipped, non-reversible counts, and unresolved side effects.
-    traces: [R5.1, R5.3]
+    criterion: Reversible tools restore exactly, compensatable tools issue corrective actions and log differences, irreversible tools are skipped and logged, and mixed tiers work within one rollback.
+    traces: [R4.1, R4.2, R4.3, R4.4]
   - id: AC5
-    criterion: Non-fail-fast mode continues undo after step failures.
-    traces: [R4.4]
-  - id: AC6
-    criterion: Tool registration fails when undo mode is missing or invalid.
-    traces: [R1.1]
-  - id: AC7
-    criterion: Invocation crumbs store required undo metadata for reversible, compensating, and snapshot modes, and explicitly mark non-reversible items.
-    traces: [R2.1, R2.2, R2.3]
-  - id: AC8
-    criterion: Undo execution honors idempotency guarantees for tools that declare idempotent undo.
-    traces: [R4.1, R4.3]
+    criterion: Rollback summary includes success, failure, skipped, non-reversible counts, and unresolved side effects, with undo crumbs linked to originals.
+    traces: [R5.1, R5.2, R5.3]

--- a/docs/specs/product-requirements/prd006-stitch-essential-toolset.yaml
+++ b/docs/specs/product-requirements/prd006-stitch-essential-toolset.yaml
@@ -1,15 +1,16 @@
 id: prd006-stitch-essential-toolset
-title: Stitch Essential Toolset and Boundaries
+title: Essential Toolset and Model Adapter
 
 problem: |
-  Stitch runtime needs a minimal, safe, and deterministic tool surface for
-  specification-to-code generation. Without a constrained toolset and explicit
-  boundaries, runtime responsibilities can overlap orchestrator concerns and
-  increase failure risk.
+  The runtime needs a minimal, safe tool surface for specification-to-code
+  generation. invoke_llm must be a boundary tool declared in the Machine, not a
+  special-cased component outside the dispatch cycle. Without the Model Adapter
+  pattern, provider-specific logic leaks into the Engine, model swapping requires
+  code changes, and token accounting fragments across call sites.
 
 goals:
-  - G1: Define the out-of-the-gate essential tool inventory.
-  - G2: Define stable tool contracts and naming for orchestrator integration.
+  - G1: Define the essential tool inventory for specification-to-code generation.
+  - G2: Define invoke_llm as a boundary tool with the Model Adapter pattern.
   - G3: Enforce orchestrator-runtime separation of concerns.
   - G4: Define baseline safety and audit requirements for all essential tools.
 
@@ -17,18 +18,20 @@ requirements:
   R1:
     title: Essential Tool Inventory
     items:
-    - R1.1: Runtime must provide llm.generate for model completion in the internal loop.
+    - R1.1: Runtime must provide invoke_llm as a boundary tool for model completion.
     - R1.2: Runtime must provide find_files and find_text for codebase discovery and content lookup.
     - R1.3: Runtime must provide read_file for bounded content retrieval.
     - R1.4: Runtime must provide edit_file and write_file for deterministic code mutation.
     - R1.5: Runtime must provide build_target and get_errors for validation execution.
     - R1.6: Runtime must provide ask_user for requesting human or agent guidance on ambiguous decisions.
   R2:
-    title: Tool Contract Stability
+    title: Model Adapter Pattern
     items:
-    - R2.1: Each essential tool must have a versioned descriptor with required inputs, outputs, and error codes.
-    - R2.2: Tool names must be stable across releases for orchestrator compatibility.
-    - R2.3: Essential tools must produce structured machine-readable results in addition to human-readable summaries.
+    - R2.1: invoke_llm must be the only tool that crosses the inference boundary, declared in the Machine with signal set LLMResponded and BudgetExceeded.
+    - R2.2: PromptAssembler must build provider-agnostic prompts from current state, conversation history, and state-filtered manifest.
+    - R2.3: ProviderAdapter must translate provider-agnostic prompts to provider-specific API calls and replies back, one implementation per provider.
+    - R2.4: ResponseParser must normalize provider replies (tool calls, completion, free text) into a uniform ToolCallIntent result.
+    - R2.5: LLMConfig must be a YAML field (provider, model, temperature, limits) so model swapping is a config change, not a code change.
   R3:
     title: Orchestrator Boundary
     items:
@@ -45,7 +48,7 @@ requirements:
     title: Audit and Observability
     items:
     - R5.1: Every tool invocation attempt must generate a correlated crumb record.
-    - R5.2: Tool result payloads must include status and normalized error metadata when failed.
+    - R5.2: invoke_llm must aggregate token usage, latency, and cost at a single instrumentation point.
     - R5.3: Tool events must include assignment id, trail id, and call id when available.
 non_goals:
   - Define git workflow operations inside stitch runtime.
@@ -53,26 +56,26 @@ non_goals:
   - Define MCP integration as a release-1 requirement.
 
 semantic_model:
-  observe: "Tool registry descriptors, stash entries gating the active trail, workspace path boundaries, and build target allowlists from configuration"
-  reason: "Resolve the essential tool surface (llm.generate, find_files, find_text, read_file, edit_file, write_file, build_target, get_errors, ask_user), enforce workspace path boundaries on mutation tools, enforce target allowlists on build_target, and reject unconfigured or disallowed tools"
-  produce: "Versioned tool descriptors with stable names, structured machine-readable results, correlated crumb records for every invocation attempt, and normalized error metadata for failed calls"
+  observe: "Machine transition table with invoke_llm as a boundary tool, Registry tool declarations, LLMConfig (provider, model, temperature), conversation history, and state-filtered tool manifest"
+  reason: "Dispatch invoke_llm through the Engine like any other tool, assemble a provider-agnostic prompt from state and history, adapt it to the provider's API format, parse the reply into ToolCallIntent objects, and emit LLMResponded or BudgetExceeded signals for Machine routing"
+  produce: "ToolCallIntent objects with parsed JSON arguments, LLMResponded and BudgetExceeded signals for Machine routing, token usage and cost aggregated per invocation, and correlated crumb records for audit"
 
 acceptance_criteria:
   - id: AC1
-    criterion: Essential inventory includes llm.generate, find_files, find_text, read_file, edit_file, write_file, build_target, get_errors, and ask_user.
+    criterion: Essential inventory includes invoke_llm, find_files, find_text, read_file, edit_file, write_file, build_target, get_errors, and ask_user.
     traces: [R1.1, R1.2, R1.3, R1.4, R1.5, R1.6]
   - id: AC2
-    criterion: All essential tools publish versioned descriptors with stable names and structured outputs.
-    traces: [R2.1, R2.2, R2.3]
+    criterion: invoke_llm is the only inference boundary tool, declared in the Machine with LLMResponded and BudgetExceeded signals.
+    traces: [R2.1]
   - id: AC3
+    criterion: PromptAssembler builds provider-agnostic prompts, ProviderAdapter translates to provider API, ResponseParser normalizes replies, and LLMConfig enables model swapping via YAML.
+    traces: [R2.2, R2.3, R2.4, R2.5]
+  - id: AC4
     criterion: Runtime rejects unconfigured tools and does not expose git lifecycle tools.
     traces: [R3.1, R3.2, R3.3]
-  - id: AC4
-    criterion: Mutation tools enforce workspace boundaries and deterministic no-partial-write behavior.
-    traces: [R4.1, R4.2]
   - id: AC5
-    criterion: build_target target allowlist enforcement is implemented.
-    traces: [R4.3]
+    criterion: Mutation tools enforce workspace boundaries and deterministic no-partial-write behavior, and build_target enforces target allowlist.
+    traces: [R4.1, R4.2, R4.3]
   - id: AC6
-    criterion: Every tool call is auditable with correlated crumb and normalized failure metadata.
+    criterion: Every tool call is auditable with correlated crumb, and invoke_llm aggregates token usage and cost at one point.
     traces: [R5.1, R5.2, R5.3]

--- a/docs/specs/product-requirements/prd024-llm-degradation-detection.yaml
+++ b/docs/specs/product-requirements/prd024-llm-degradation-detection.yaml
@@ -1,93 +1,82 @@
 id: prd024-llm-degradation-detection
-title: LLM Degradation Detection
+title: Outcome Classifier
 
 problem: |
-  LLMs can enter degraded states during multi-turn coding loops. Observed
-  patterns include: emitting 1-2 line edits with build/test after each one,
-  creating files without reading the codebase first, spinning on read-only
-  exploration without making changes, and oscillating between edits that
-  undo each other. No existing coding agent (as of 2026-04) detects these
-  patterns — they rely entirely on hard limits (max_turns, token budgets)
-  which waste remaining budget on unproductive work.
-
-  The loop must always collect per-turn statistics and expose them in the
-  LoopResult. Optionally, it can use those statistics for early termination
-  when degradation thresholds are crossed.
+  Evaluation that reports only pass or fail says what happened, never why. When a
+  dashboard shows a middling success rate, teams cannot distinguish whether the model
+  is too weak, the tasks are too hard, or the harness is misconfigured. The existing
+  degradation detection (declining edits, error streaks) is one signal within a
+  broader taxonomy. Without the Outcome Classifier pattern, every failure looks the
+  same and remediation is guesswork.
 
 goals:
-  - G1: Define per-turn metrics that characterize LLM productivity.
-  - G2: Define always-on statistics that are reported in every LoopResult.
-  - G3: Define degradation signals with configurable thresholds.
-  - G4: Define the progress_stalled exit reason and its reporting.
+  - G1: Define a four-valued convergence taxonomy (Clean, Recovery, Stuck, Divergent).
+  - G2: Define a pure, inference-free classifier function from execution to type.
+  - G3: Preserve existing TurnMetrics and degradation signals as inputs to Stuck classification.
+  - G4: Define per-type remediation guidance for orchestrator recovery decisions.
 
 requirements:
   R1:
-    title: Per-Turn Metrics Collection
+    title: Convergence Taxonomy
     items:
-    - R1.1: Loop must collect TurnMetrics after every turn regardless of configuration.
-    - R1.2: TurnMetrics must include lines_changed (additions + removals from mutation tools).
-    - R1.3: TurnMetrics must include tool_call_count and mutation_count per turn.
-    - R1.4: TurnMetrics must include error_count (tool results with is_error=true).
-    - R1.5: TurnMetrics must include output_tokens from the LLM response.
-    - R1.6: TurnMetrics must include read_count (find_files, find_text, read_file calls).
-    - R1.7: TurnMetrics must include validation_count (build_target, get_errors calls).
-    - R1.8: TurnMetrics must include files_created_without_read — count of write_file calls where the target path was not read (read_file) or discovered (find_files) in the current or preceding 2 turns.
+    - R1.1: Runtime must classify every completed or exhausted execution into exactly one of Clean, Recovery, Stuck, or Divergent.
+    - R1.2: Clean means Succeeded with no retry cycles (handled on first approach).
+    - R1.3: Recovery means Succeeded with one or more Composing-to-Validating-to-Composing cycles (self-corrected after validation failures).
+    - R1.4: Stuck means Failed (budget exhausted) with repeated identical dispatches late in execution (cycling).
+    - R1.5: Divergent means Failed (budget exhausted) with varied but unproductive dispatches (not converging).
   R2:
-    title: Always-On Loop Statistics
+    title: Classifier Function
     items:
-    - R2.1: LoopResult must include aggregate statistics computed from all TurnMetrics.
-    - R2.2: Aggregate statistics must include total_lines_changed, total_mutations, total_errors, total_turns.
-    - R2.3: Aggregate statistics must include avg_lines_per_mutation_turn — mean lines_changed across turns that had at least one mutation.
-    - R2.4: Aggregate statistics must include read_to_mutate_ratio — total read_count divided by total mutation_count.
-    - R2.5: Aggregate statistics must include validation_to_mutate_ratio — total validation_count divided by total mutation_count.
-    - R2.6: Aggregate statistics must include blind_write_count — sum of files_created_without_read across all turns.
+    - R2.1: Classifier must be a pure, inference-free function from execution record to ConvergenceType.
+    - R2.2: Classifier must read the execution's state-visit sequence and apply three detectors: cycle counter, repetition detector, and terminal-state check.
+    - R2.3: Classification must be deterministic — the same execution always yields the same type.
+    - R2.4: Classifier must not require access to model, tools, or workspace — only the execution record.
   R3:
-    title: Degradation Signals
+    title: Degradation Signals as Stuck Inputs
     items:
-    - R3.1: Signal "declining_edits" — when average lines_changed over a sliding window drops below min_lines_per_turn AND the least-squares slope of lines_changed over the window is at or below slope_threshold.
-    - R3.2: Signal "error_streak" — when error_count is greater than zero for max_consecutive_error_turns consecutive turns from the tail of the window.
-    - R3.3: Signal "read_only_spinning" — when mutation_count is zero for max_readonly_turns consecutive turns while read_count is greater than zero.
-    - R3.4: Signal "blind_creation" — when files_created_without_read exceeds max_blind_writes within the sliding window.
-    - R3.5: Signal "validation_heavy" — when validation_to_mutate_ratio over the window exceeds max_validation_ratio, indicating the model is running build/test far more than it is writing code.
+    - R3.1: Existing TurnMetrics (lines_changed, tool_call_count, mutation_count, error_count, output_tokens) must feed the repetition detector.
+    - R3.2: Declining edit volume via least-squares slope must contribute to Stuck classification.
+    - R3.3: Consecutive error turns must contribute to Stuck classification.
+    - R3.4: Read-only spinning and blind creation signals must contribute to Divergent classification.
   R4:
-    title: Convergence Configuration
+    title: Per-Type Remediation
     items:
-    - R4.1: All degradation signals must be individually configurable with thresholds.
-    - R4.2: A master enabled flag must control whether signals trigger early termination.
-    - R4.3: When enabled is false, metrics are still collected and statistics still reported — only termination is suppressed.
-    - R4.4: Default configuration must be disabled (enabled=false) so existing loops are unaffected.
-    - R4.5: Window size must be configurable with a minimum of 3 and default of 5.
+    - R4.1: Clean outcomes require no remediation.
+    - R4.2: Recovery outcomes suggest budget sufficiency — the model self-corrected.
+    - R4.3: Stuck outcomes suggest prompt or model change to break the cycle.
+    - R4.4: Divergent outcomes suggest tighter Machine or tool constraints to prevent off-track exploration.
   R5:
-    title: Exit and Reporting
+    title: Grid Aggregation
     items:
-    - R5.1: When any degradation signal fires, the loop must exit with progress_stalled.
-    - R5.2: The LoopResult convergence_detail must identify which signal fired and the metric values that triggered it.
-    - R5.3: The orchestrator must be able to distinguish progress_stalled from other exit reasons to select a recovery strategy.
-
+    - R5.1: EvalHarness must collect ConvergenceTypes across a grid of (model, task, profile) and aggregate per-type rates.
+    - R5.2: Per-type rates must sum to 1.0 for each (model, profile) pair.
+    - R5.3: Pass rate must be defined as Clean plus Recovery.
+    - R5.4: Regression detection must flag shifts from Clean to Recovery as prompt degradation even at constant pass rate.
 non_goals:
   - Injecting corrective prompts mid-loop to change LLM behavior.
   - Modifying tool availability or context during the loop.
   - Automatic recovery within the loop (recovery is orchestrator responsibility).
   - Detecting semantic correctness of generated code.
+  - Classifying infrastructure errors (crash, timeout before any dispatch) — these are recorded before classification.
 
 semantic_model:
-  observe: "Per-turn TurnMetrics (lines_changed, tool_call_count, mutation_count, error_count, output_tokens, read_count, validation_count, files_created_without_read) and a sliding window of recent turns"
-  reason: "Compute aggregate statistics from all TurnMetrics, evaluate degradation signals (declining_edits via least-squares slope, error_streak, read_only_spinning, blind_creation, validation_heavy) against configured thresholds, and exit with progress_stalled when any signal fires and the master enabled flag is true"
-  produce: "Always-on aggregate statistics in every LoopResult (total lines, mutations, errors, turns, ratios), convergence_detail identifying which signal fired and the triggering metric values, and a progress_stalled exit reason distinguishable from other exit reasons"
+  observe: "Execution record (state, signal, tool, result tuples), TurnMetrics per dispatch cycle (lines_changed, tool_call_count, mutation_count, error_count, output_tokens), terminal state (Succeeded or Failed), and state-visit sequence"
+  reason: "Count retry cycles (Validating-to-Composing returns), detect repetition (same state-tool pair recurring late), check terminal state, apply decision tree: Succeeded with no cycles is Clean, Succeeded with cycles is Recovery, Failed with repetition is Stuck, Failed without is Divergent"
+  produce: "ConvergenceType (Clean, Recovery, Stuck, Divergent) per execution, per-type remediation guidance for orchestrator recovery, and grid aggregation with per-type rates summing to 1.0"
 
 acceptance_criteria:
   - id: AC1
-    criterion: TurnMetrics are collected after every turn with accurate lines_changed, mutation_count, error_count, read_count, validation_count, and files_created_without_read.
-    traces: [R1.1, R1.2, R1.3, R1.4, R1.5, R1.6, R1.7, R1.8]
+    criterion: Every completed or exhausted execution is classified into exactly one of Clean, Recovery, Stuck, or Divergent with the documented terminal-state and pattern definitions.
+    traces: [R1.1, R1.2, R1.3, R1.4, R1.5]
   - id: AC2
-    criterion: LoopResult always includes aggregate statistics regardless of convergence config.
-    traces: [R2.1, R2.2, R2.3, R2.4, R2.5, R2.6]
+    criterion: Classifier is a pure, deterministic, inference-free function reading only the execution record with three detectors (cycle, repetition, terminal-state).
+    traces: [R2.1, R2.2, R2.3, R2.4]
   - id: AC3
-    criterion: Each degradation signal fires at the documented threshold and does not fire below it.
-    traces: [R3.1, R3.2, R3.3, R3.4, R3.5]
+    criterion: Existing TurnMetrics and degradation signals (declining edits, error streaks, read-only spinning, blind creation) feed Stuck and Divergent classification.
+    traces: [R3.1, R3.2, R3.3, R3.4]
   - id: AC4
-    criterion: When enabled is false, no signal triggers early termination but metrics and statistics are still collected and reported. All degradation signals are individually configurable with thresholds and window size is configurable with a minimum of 3 and default of 5.
-    traces: [R4.1, R4.2, R4.3, R4.4, R4.5]
+    criterion: Per-type remediation guidance is produced: Clean (no action), Recovery (budget sufficient), Stuck (prompt/model change), Divergent (tighter constraints).
+    traces: [R4.1, R4.2, R4.3, R4.4]
   - id: AC5
-    criterion: progress_stalled exit includes convergence_detail identifying the signal and triggering metric values.
-    traces: [R5.1, R5.2, R5.3]
+    criterion: Grid aggregation produces per-type rates summing to 1.0, pass rate as Clean plus Recovery, and regression detection for Clean-to-Recovery shifts.
+    traces: [R5.1, R5.2, R5.3, R5.4]

--- a/docs/specs/product-requirements/prd027-trace-instrumentation.yaml
+++ b/docs/specs/product-requirements/prd027-trace-instrumentation.yaml
@@ -1,0 +1,71 @@
+id: prd027-trace-instrumentation
+title: Trace Instrumentation
+
+problem: |
+  Agent execution is opaque without instrumentation. The execution record (crumbs)
+  is the semantic record for evaluators and auditors, but operators need a different
+  view: timed, hierarchical, cross-service, and visualizable in standard backends.
+  Without the Trace Instrumentation pattern, debugging falls back on ad hoc logging,
+  per-step timing is unavailable, and multi-agent executions cannot correlate into a
+  single distributed trace.
+
+goals:
+  - G1: Define a Tracer port that the Engine requires without importing OpenTelemetry.
+  - G2: Map each Engine transition to an OpenTelemetry span with a four-type span tree.
+  - G3: Define trace-context propagation across agent delegation boundaries.
+  - G4: Define adapter selection as configuration, not code.
+
+requirements:
+  R1:
+    title: Tracer Port
+    items:
+    - R1.1: Runtime must define a Tracer port declaring operations the Engine needs (start span, end span, record event, set attribute, propagate context).
+    - R1.2: Engine must not import OpenTelemetry SDK types directly; all telemetry goes through the Tracer port.
+    - R1.3: Adapters must implement the Tracer port: OTel adapter (OTLP/stdout/file exporters), NDJSON file adapter (CLI default), and no-op adapter (tests and benchmarks).
+    - R1.4: Adapter selection must be configuration-driven, not code-driven.
+  R2:
+    title: Span Tree
+    items:
+    - R2.1: Each execution must produce a span tree with four span types: agent.run (root), invoke_agent (engine-cycle iterations), chat (LLM invocations), and execute_tool (tool dispatches).
+    - R2.2: agent.run span must carry profile, machine, and budget attributes.
+    - R2.3: execute_tool spans must name the tool and record the returned signal.
+    - R2.4: Span hierarchy must mirror the Machine's structure.
+  R3:
+    title: Trace Context Propagation
+    items:
+    - R3.1: Trace context must propagate across agent delegation boundaries via W3C Trace Context.
+    - R3.2: Child executions must nest under the parent's trace, not start a new trace.
+    - R3.3: Boundary tools must carry the trace context into child executions.
+  R4:
+    title: Dual Record
+    items:
+    - R4.1: The execution record (crumbs) remains the semantic record for evaluators and auditors.
+    - R4.2: The OTel trace is the operational record for operators and SREs.
+    - R4.3: Both records come from the same execution; neither replaces the other.
+    - R4.4: Structured logging via log/slog must remain as a fallback when no Tracer adapter is configured.
+non_goals:
+  - Replace the crumb-based execution record with OTel traces.
+  - Define OTel collector or backend deployment configuration.
+  - Define custom span attributes beyond the four span types.
+
+semantic_model:
+  observe: "Engine dispatch cycles (state, signal, tool, result), tool execution durations, LLM invocation token counts, and agent delegation boundaries"
+  reason: "Start a root agent.run span per execution, nest invoke_agent spans per engine-cycle iteration, nest chat and execute_tool spans per LLM invocation and tool dispatch, propagate trace context across delegation boundaries, and route telemetry through the Tracer port to the configured adapter"
+  produce: "Hierarchical OpenTelemetry span tree with four span types, W3C trace context propagated to child executions, and structured logging fallback via log/slog"
+
+acceptance_criteria:
+  - id: AC1
+    criterion: Tracer port is defined with start/end span, record event, set attribute, and propagate context operations, and Engine does not import OTel SDK types.
+    traces: [R1.1, R1.2]
+  - id: AC2
+    criterion: OTel, NDJSON file, and no-op adapters implement the Tracer port with configuration-driven selection.
+    traces: [R1.3, R1.4]
+  - id: AC3
+    criterion: Each execution produces a four-type span tree (agent.run, invoke_agent, chat, execute_tool) mirroring the Machine structure.
+    traces: [R2.1, R2.2, R2.3, R2.4]
+  - id: AC4
+    criterion: Trace context propagates across delegation boundaries via W3C Trace Context, and child executions nest under the parent trace.
+    traces: [R3.1, R3.2, R3.3]
+  - id: AC5
+    criterion: Execution crumbs remain the semantic record and OTel traces the operational record, with log/slog fallback.
+    traces: [R4.1, R4.2, R4.3, R4.4]

--- a/docs/specs/product-requirements/prd028-agent-delegation.yaml
+++ b/docs/specs/product-requirements/prd028-agent-delegation.yaml
@@ -1,0 +1,67 @@
+id: prd028-agent-delegation
+title: Agent Delegation
+
+problem: |
+  Multi-agent coordination through imperative wiring couples parent and child control
+  flow. The parent must know the child's states, tools, and transitions. Without the
+  Agent Delegation pattern, hierarchy requires nested machines or shared state, and
+  each machine loses independent validation, audit, and rollback.
+
+goals:
+  - G1: Define non-terminal boundary tools that compose sub-machines and child agents.
+  - G2: Keep each Machine flat and independently validatable.
+  - G3: Define profile references as the delegation mechanism, not code dependencies.
+  - G4: Define independent audit and rollback for child executions.
+
+requirements:
+  R1:
+    title: Non-Terminal Boundary Tools
+    items:
+    - R1.1: Boundary tools must obey the ordinary Tool Contract (parameters, signals, side effects, UndoMemento) but cross into an external actor.
+    - R1.2: Boundary tool Execute must run an entire child execution and return a single signal to the parent Machine.
+    - R1.3: Boundary tool types must include child process (run_agent, execute_task) and nested machine (run_point).
+    - R1.4: Boundary tools must carry a profile reference (config.profile or config.point_machine), not a code dependency.
+  R2:
+    title: Parent-Child Separation
+    items:
+    - R2.1: Parent Machine must route on the returned signal only, with no knowledge of the child's states or tools.
+    - R2.2: Child execution must be invisible above the boundary — the parent sees only the profile path and parameter contract.
+    - R2.3: Child must see only its sub-task, not the parent's context.
+    - R2.4: Each Machine must stay flat and independently validatable.
+  R3:
+    title: Independent Audit and Rollback
+    items:
+    - R3.1: Child executions must be independently auditable with their own crumb trails.
+    - R3.2: Child executions must be independently rollbackable via their own execution records.
+    - R3.3: Trace context must propagate from parent to child across the delegation boundary.
+    - R3.4: Resource authority must narrow as work is delegated downward.
+  R4:
+    title: Composition Tiers
+    items:
+    - R4.1: The canonical composition must support a three-tier process stack (bench, evaluator, generator).
+    - R4.2: Each tier must be a separate profile with its own Machine.
+    - R4.3: Bench must dispatch launch_eval subprocess tools to start evaluators.
+    - R4.4: Evaluators must run generators as nested machines via run_point.
+non_goals:
+  - Define multi-agent orchestration inside the runtime (orchestrator-owned).
+  - Define inter-agent messaging protocols.
+  - Define resource quota management across delegation tiers.
+
+semantic_model:
+  observe: "Parent Machine transition table, boundary tool declarations with profile references, child profile configurations, and trace context from the parent execution"
+  reason: "Dispatch a boundary tool that starts a child execution with a sub-task spec and trace context, let the child run its own agent.run to completion, collapse the child execution into a single signal, and return it to the parent Machine for routing"
+  produce: "Child execution crumb trails (independently auditable and rollbackable), single signal to parent Machine, propagated trace context, and narrowed resource authority for the child"
+
+acceptance_criteria:
+  - id: AC1
+    criterion: Non-terminal boundary tools obey the Tool Contract, run child executions, return single signals, and carry profile references.
+    traces: [R1.1, R1.2, R1.3, R1.4]
+  - id: AC2
+    criterion: Parent routes on returned signal only, child is invisible above the boundary, and each Machine stays flat and validatable.
+    traces: [R2.1, R2.2, R2.3, R2.4]
+  - id: AC3
+    criterion: Child executions are independently auditable and rollbackable, trace context propagates, and resource authority narrows downward.
+    traces: [R3.1, R3.2, R3.3, R3.4]
+  - id: AC4
+    criterion: Three-tier composition (bench, evaluator, generator) is supported with separate profiles and Machines per tier.
+    traces: [R4.1, R4.2, R4.3, R4.4]

--- a/docs/specs/product-requirements/prd029-approval-gate.yaml
+++ b/docs/specs/product-requirements/prd029-approval-gate.yaml
@@ -1,0 +1,77 @@
+id: prd029-approval-gate
+title: Approval Gate
+
+problem: |
+  Agents that modify production systems need confirmation gates before deploying,
+  deleting data, or provisioning. Without the Approval Gate pattern, gates are
+  bolted onto control flow imperatively via callbacks or polling, both of which
+  fail on process restart, lose execution context, and lack shared infrastructure.
+  The gate must be a declared Machine transition, not a procedural interruption.
+
+goals:
+  - G1: Define Approval Gate as a Machine transition with a signal triplet.
+  - G2: Define checkpoint-based suspension that survives process boundaries.
+  - G3: Define resume and rollback paths on approval or rejection.
+  - G4: Define the control-plane API for external authority decisions.
+
+requirements:
+  R1:
+    title: Gate Signal Triplet
+    items:
+    - R1.1: Approval Gate must use the signal triplet AwaitApproval, Approved, and Rejected as ordinary Machine signals.
+    - R1.2: The signals must be handled by ordinary transitions, with nothing special to the Engine.
+    - R1.3: SuspendTool must emit AwaitApproval with a human-readable action summary.
+    - R1.4: Gate placement must follow reversibility tiers — gate before irreversible tools, not before reversible ones.
+  R2:
+    title: Suspension and Checkpoint
+    items:
+    - R2.1: On AwaitApproval, the Engine must checkpoint all three state layers (agent, domain, workspace).
+    - R2.2: The Engine must notify the authority with the action summary and checkpoint reference.
+    - R2.3: The Engine must exit the dispatch loop after checkpointing, allowing the process to terminate.
+    - R2.4: An arbitrary time may pass with full state living in the checkpoint.
+  R3:
+    title: Resume and Rollback
+    items:
+    - R3.1: On Approved, ResumeEngine must load the checkpoint and re-enter the dispatch loop, continuing past the gate.
+    - R3.2: On Rejected, the Machine must route to rollback or an alternative path.
+    - R3.3: ResumeEngine must restore all three state layers from the checkpoint.
+    - R3.4: Resumed execution must continue with the pre-suspension context intact.
+  R4:
+    title: Control-Plane API
+    items:
+    - R4.1: The control-plane API must receive the authority's decision (approve or reject) by checkpoint reference.
+    - R4.2: The API must be callable by human authorities, policy engines, or chains of approvers.
+    - R4.3: The decision must be auditable with approver identity, timestamp, and reason.
+    - R4.4: Multiple authorities must be able to sign off in sequence via chained gates.
+  R5:
+    title: Audit Trail
+    items:
+    - R5.1: Every gate suspension must persist a crumb with checkpoint reference and action summary.
+    - R5.2: Every approval or rejection must persist a crumb with approver identity and decision.
+    - R5.3: The gate lifecycle (suspend, decide, resume or rollback) must be reconstructable from crumbs.
+non_goals:
+  - Define the authority's decision-making logic.
+  - Define authentication or authorization for approvers.
+  - Define notification delivery mechanisms (email, Slack, etc.).
+
+semantic_model:
+  observe: "Machine transitions with AwaitApproval signals, checkpoint snapshots of agent/domain/workspace state, authority decisions (approve or reject), and action summaries for human review"
+  reason: "Dispatch the SuspendTool which emits AwaitApproval, checkpoint all three state layers, notify the authority with the action summary, exit the loop, and on decision load the checkpoint and resume past the gate or route to rollback"
+  produce: "Checkpointed execution state surviving process boundaries, audited gate decisions with approver identity, and resumed or rolled-back execution based on authority decision"
+
+acceptance_criteria:
+  - id: AC1
+    criterion: Approval Gate uses AwaitApproval, Approved, and Rejected as ordinary Machine signals handled by ordinary transitions, with SuspendTool emitting AwaitApproval with action summary.
+    traces: [R1.1, R1.2, R1.3, R1.4]
+  - id: AC2
+    criterion: On AwaitApproval, Engine checkpoints all three state layers, notifies the authority, and exits the loop, allowing process termination and arbitrary time passage.
+    traces: [R2.1, R2.2, R2.3, R2.4]
+  - id: AC3
+    criterion: On Approved, ResumeEngine loads checkpoint and continues; on Rejected, Machine routes to rollback; all three state layers are restored.
+    traces: [R3.1, R3.2, R3.3, R3.4]
+  - id: AC4
+    criterion: Control-plane API receives decisions by checkpoint reference, supports human/policy/chained approvers, and records auditable decisions.
+    traces: [R4.1, R4.2, R4.3, R4.4]
+  - id: AC5
+    criterion: Gate lifecycle (suspend, decide, resume or rollback) is reconstructable from crumbs with checkpoint reference, action summary, and approver identity.
+    traces: [R5.1, R5.2, R5.3]

--- a/docs/specs/product-requirements/prd030-runtime-probe.yaml
+++ b/docs/specs/product-requirements/prd030-runtime-probe.yaml
@@ -1,0 +1,79 @@
+id: prd030-runtime-probe
+title: Runtime Probe
+
+problem: |
+  Imperative agents are opaque at runtime. The only visibility is log output the
+  developer thought to emit, and the only control is crude — SIGSTOP to pause,
+  SIGKILL to abort, restart to roll back. Without the Runtime Probe pattern,
+  operators cannot ask what state the agent is in, inject a signal, or roll back
+  to a checkpoint without killing the process. The Machine's declared state space
+  makes live inspection and safe signal injection possible.
+
+goals:
+  - G1: Define a control-plane server attached to the running Engine.
+  - G2: Define read-plane endpoints for non-blocking state and history queries.
+  - G3: Define control-plane signal injection within the Machine's declared state space.
+  - G4: Define lifecycle tools that operate on persisted checkpoints.
+
+requirements:
+  R1:
+    title: Monitor Recorder
+    items:
+    - R1.1: MonitorRecorder must be an in-process observer the Engine notifies after every dispatch.
+    - R1.2: MonitorRecorder must append a RunEvent (state, signal, tool, result, iteration, timestamp, remaining budget) to the Store.
+    - R1.3: Recording must happen after the transition is committed so it can neither block nor alter it.
+    - R1.4: Recording must be serialization only, with no computation.
+  R2:
+    title: Store and Read Plane
+    items:
+    - R2.1: Store must be a bounded in-memory ring of the most recent N events, dropping oldest when full.
+    - R2.2: Read plane must expose /read_state returning a non-blocking snapshot (current state, last signal, iteration, budget, recent events).
+    - R2.3: Read plane must expose /stream_events pushing each RunEvent over SSE, with gap indicators for clients that fall behind.
+    - R2.4: Store must export the same data as OTel gauges and counters for standard dashboards.
+  R3:
+    title: Control Plane
+    items:
+    - R3.1: Control plane must expose /emit_signal enqueuing a signal the Engine dequeues and routes at its next cycle.
+    - R3.2: Injected signals must be validated against the Machine — signals invalid in the current state must be rejected with a machine-violation error.
+    - R3.3: Control plane must expose /lifecycle_control accepting pause, resume, exit, and rollback commands.
+    - R3.4: Pause must reuse the Approval Gate mechanism, and rollback must reuse the checkpoint mechanism.
+  R4:
+    title: Lifecycle Tools
+    items:
+    - R4.1: LifecycleTool must be a separate agent with its own Machine and profile that operates on persisted checkpoints.
+    - R4.2: LifecycleTool must survive restarts and manage terminated agents.
+    - R4.3: LifecycleTool must browse checkpoint history, select a restore point, and trigger restoration.
+    - R4.4: LifecycleTool is the State Interpreter applied to its own operations — recursion, not special-casing.
+  R5:
+    title: Loop Hooks
+    items:
+    - R5.1: LoopHooks must be in-process policy callbacks (before/after dispatch, on state change, on budget threshold).
+    - R5.2: LoopHooks must observe but never alter the transition.
+    - R5.3: LoopHooks must be the lightest probe mode with no network or serialization.
+    - R5.4: An agent must run identically with or without any probe attached.
+non_goals:
+  - Define security model for HTTP endpoints (localhost binding or auth middleware is deployment-specific).
+  - Replace post-hoc trace analysis for short-running agents.
+  - Define OTel collector or dashboard deployment.
+
+semantic_model:
+  observe: "Engine dispatch cycles (state, signal, tool, result, iteration, budget), Machine declared state space and transitions, checkpoint snapshots, and external control commands (pause, resume, exit, rollback, emit signal)"
+  reason: "After each committed dispatch, record a RunEvent to the bounded Store. Serve non-blocking state snapshots and SSE event streams to observers. Enqueue externally injected signals for the Engine to dequeue and route at its next cycle, validating against the Machine. Translate lifecycle commands to internal signals reusing Approval Gate and checkpoint mechanisms."
+  produce: "Bounded event ring for live inspection, SSE event streams for connected clients, machine-validated signal injection, OTel metric export, and lifecycle tools operating on persisted checkpoints"
+
+acceptance_criteria:
+  - id: AC1
+    criterion: MonitorRecorder records RunEvents after committed transitions without blocking or altering them, and recording is serialization only.
+    traces: [R1.1, R1.2, R1.3, R1.4]
+  - id: AC2
+    criterion: Store is a bounded ring with /read_state snapshots, /stream_events SSE, and OTel metric export.
+    traces: [R2.1, R2.2, R2.3, R2.4]
+  - id: AC3
+    criterion: /emit_signal enqueues machine-validated signals, invalid signals are rejected, and /lifecycle_control accepts pause/resume/exit/rollback reusing Approval Gate and checkpoint mechanisms.
+    traces: [R3.1, R3.2, R3.3, R3.4]
+  - id: AC4
+    criterion: LifecycleTool is a separate agent operating on persisted checkpoints, surviving restarts, and using the State Interpreter recursively.
+    traces: [R4.1, R4.2, R4.3, R4.4]
+  - id: AC5
+    criterion: LoopHooks observe without altering transitions, require no network or serialization, and the agent runs identically with or without any probe.
+    traces: [R5.1, R5.2, R5.3, R5.4]

--- a/docs/specs/use-cases/rel01.0-uc001-agentic-loop-core.yaml
+++ b/docs/specs/use-cases/rel01.0-uc001-agentic-loop-core.yaml
@@ -1,53 +1,52 @@
 id: rel01.0-uc001-agentic-loop-core
 title: Core Agentic Loop
 summary: |
-  Execute the canonical loop where a prompt is mapped to a trail, llm.generate is invoked
-  as a standard tool, and the response is routed to either crumb insertion or next invocation.
-actor: Orchestrator invoking the stitch runtime for code generation
+  Execute the canonical dispatch cycle where the Engine interprets the Machine,
+  invoke_llm is dispatched as a boundary tool, and the returned signal routes the
+  next transition until a terminal state is reached.
+actor: Orchestrator invoking the runtime Engine for code generation
 trigger: Orchestrator sends an assignment envelope with a prompt and trail reference
 flow:
-  - F1: "Receive orchestrator assignment envelope and initialize stitch execution context [StitchBoundaryAdapter]"
-  - F2: "Receive prompt input from user [AgentLoopOrchestrator]"
-  - F3: "Map prompt to existing trail or create a new trail [AgentLoopOrchestrator, TrailManager]"
-  - F4: "Create canonical ToolCall for llm.generate [AgentLoopOrchestrator, ToolCallInterpreter]"
-  - F5: "Validate availability, decode, and semantics [InvocationValidator]"
-  - F6: "Compose prompt from crumb context and stash references, then execute llm.generate with timeout handling [PermissionExecutor, LLMToolAdapter]"
-  - F7: "Route response to terminal or actionable branch [ModelResponseRouter]"
-  - F8: "Terminal branch: insert output crumb and return terminal response [ModelResponseRouter, CrumbLedger]"
-  - F9: "Actionable branch: normalize next tool call, insert next-invocation crumb, continue loop [ModelResponseRouter, ToolCallInterpreter, CrumbLedger]"
-  - F10: "Error — trail resolution fails: reject turn and persist rejection crumb"
-  - F11: "Error — validation fails: reject invocation and persist rejection crumb"
-  - F12: "Error — llm.generate execution fails: persist execution-failed crumb with error metadata"
-  - F13: "Error — llm.generate times out: persist timeout failure crumb and return structured timeout result"
+  - F1: "Receive orchestrator assignment envelope and initialize execution context [StitchBoundaryAdapter]"
+  - F2: "Load Machine and tool declarations, validate Machine against tool signal sets [StitchBoundaryAdapter, Registry]"
+  - F3: "Create execution trail with branches_from link to assignment crumb [TrailManager]"
+  - F4: "Enter initial state and start dispatch cycle [Engine]"
+  - F5: "Dispatch invoke_llm boundary tool with state-filtered manifest [Engine, LLMToolAdapter]"
+  - F6: "LLMToolAdapter composes prompt, invokes provider, parses response into ToolCallIntent [LLMToolAdapter]"
+  - F7: "invoke_llm returns LLMResponded signal, Engine routes to next transition [Engine]"
+  - F8: "Dynamic dispatch ($tool): Engine resolves model-selected tool through Registry [Engine, Registry]"
+  - F9: "Tool Execute returns typed signal, Engine records crumb and routes to next transition [Engine, CrumbLedger]"
+  - F10: "Terminal state reached: Engine classifies outcome (Clean, Recovery, Stuck, Divergent) [Engine]"
+  - F11: "Result crumb written, trail transitions to completed or abandoned [CrumbLedger, TrailManager]"
+  - F12: "Error — Machine validation fails at load time: reject invocation before any tool executes"
+  - F13: "Error — invoke_llm times out or fails: BudgetExceeded or error signal routed by Machine"
 touchpoints:
-  - T1: "StitchBoundaryAdapter — assignment envelope validation (prd001-tool-system-components-interfaces R1, R4)"
-  - T2: "AgentLoopOrchestrator — prompt to trail mapping and loop control (prd002-trail-lifecycle-state-machine R3)"
-  - T3: "TrailManager — trail creation and activation (prd002-trail-lifecycle-state-machine R1, R2)"
-  - T4: "ToolCallInterpreter — tool call normalization (prd004-tool-invocation-validation R1)"
-  - T5: "InvocationValidator — decode and semantic validation (prd004-tool-invocation-validation R2)"
-  - T6: "PermissionExecutor — execution with OS failure mapping (prd004-tool-invocation-validation R6)"
-  - T7: "LLMToolAdapter — prompt composition and provider invocation (prd001-tool-system-components-interfaces R3)"
-  - T8: "ModelResponseRouter — terminal vs actionable classification (prd001-tool-system-components-interfaces R4)"
-  - T9: "CrumbLedger — invocation crumb persistence (prd001-tool-system-components-interfaces R5)"
+  - T1: "StitchBoundaryAdapter — assignment envelope validation and Engine startup (prd001-tool-system-components-interfaces R1, R3)"
+  - T2: "Engine — dispatch cycle interpreting Machine transitions (prd001-tool-system-components-interfaces R1, R4)"
+  - T3: "TrailManager — execution trail creation and activation (prd002-trail-lifecycle-state-machine R4)"
+  - T4: "Registry — tool name resolution and signal set validation (prd001-tool-system-components-interfaces R3, R4)"
+  - T5: "LLMToolAdapter — invoke_llm boundary tool with prompt assembly and provider invocation (prd006-stitch-essential-toolset R2)"
+  - T6: "CrumbLedger — execution crumb persistence per dispatch cycle (prd001-tool-system-components-interfaces R5)"
+  - T7: "Machine — transition table with states, signals, and terminal states (prd002-trail-lifecycle-state-machine R1, R2)"
 success_criteria:
   - id: S1
-    criterion: Exactly one primary llm.generate invocation crumb exists per loop turn
+    criterion: Exactly one invoke_llm dispatch crumb exists per Engine cycle iteration
     traces:
-      - prd001-tool-system-components-interfaces AC5
+      - prd001-tool-system-components-interfaces AC1
   - id: S2
-    criterion: Exactly one branch decision exists per loop turn
+    criterion: Engine routes signals to transitions via Machine lookup with no ad hoc classification
     traces:
-      - prd001-tool-system-components-interfaces AC4
+      - prd001-tool-system-components-interfaces AC1
   - id: S3
-    criterion: Prompt provenance for the loop turn is reconstructable from stash references or crumb attachments
+    criterion: Prompt provenance for the dispatch cycle is reconstructable from stash references or crumb attachments
     traces:
-      - prd004-tool-invocation-validation AC1
+      - prd006-stitch-essential-toolset AC2
   - id: S4
-    criterion: Trail remains auditable for replay and rollback planning
+    criterion: Execution trail remains auditable for replay and rollback planning
     traces:
-      - prd002-trail-lifecycle-state-machine AC1
+      - prd002-trail-lifecycle-state-machine AC5
   - id: S5
-    criterion: Stitch execution result can be returned to orchestrator without git operations in runtime
+    criterion: Engine classifies outcome on terminal state and returns result to orchestrator without git operations
     traces:
-      - prd001-tool-system-components-interfaces AC4
+      - prd001-tool-system-components-interfaces AC1
 test_suite: test-rel01.0

--- a/docs/specs/use-cases/rel01.0-uc002-orchestrator-stitch-boundary.yaml
+++ b/docs/specs/use-cases/rel01.0-uc002-orchestrator-stitch-boundary.yaml
@@ -1,36 +1,37 @@
 id: rel01.0-uc002-orchestrator-stitch-boundary
-title: Orchestrator Stitch Boundary
+title: Orchestrator Runtime Boundary
 summary: |
-  The orchestrator prepares an assignment envelope and invokes the stitch runtime.
-  The runtime executes the assignment, produces a result envelope, and returns it
-  to the orchestrator without performing git operations.
+  The orchestrator prepares an assignment envelope and invokes the runtime Engine.
+  The Engine interprets the Machine, produces a result envelope with outcome
+  classification, and returns it to the orchestrator without performing git operations.
 actor: External orchestrator (cobbler-scaffold)
-trigger: Orchestrator picks a ready task and creates an assignment envelope for stitch execution
+trigger: Orchestrator picks a ready task and creates an assignment envelope for Engine execution
 flow:
   - F1: "Orchestrator prepares assignment envelope with trail_id, specification references, workspace path, and execution budget"
   - F2: "Orchestrator sends AgentInvokeRequest with prompt and assignment metadata to StitchBoundaryAdapter"
-  - F3: "StitchBoundaryAdapter validates assignment envelope and initializes runtime execution context"
-  - F4: "StitchBoundaryAdapter delegates to AgentLoopOrchestrator with prompt and trail reference"
-  - F5: "AgentLoopOrchestrator runs the agentic loop (see uc001) until terminal response"
-  - F6: "StitchBoundaryAdapter packages execution summary into AgentInvokeResponse"
-  - F7: "StitchBoundaryAdapter returns result envelope to orchestrator"
-  - F8: "Error — invalid assignment envelope: reject with structured error before loop starts"
-  - F9: "Error — loop execution fails: return partial result with error metadata"
+  - F3: "StitchBoundaryAdapter validates assignment envelope and loads Machine and tool declarations"
+  - F4: "StitchBoundaryAdapter validates Machine against tool signal sets at load time"
+  - F5: "StitchBoundaryAdapter starts Engine dispatch loop (see uc001) until terminal state"
+  - F6: "Engine classifies outcome (Clean, Recovery, Stuck, Divergent) on terminal state"
+  - F7: "StitchBoundaryAdapter packages execution summary with outcome classification into AgentInvokeResponse"
+  - F8: "StitchBoundaryAdapter returns result envelope to orchestrator"
+  - F9: "Error — invalid assignment envelope: reject with structured error before Engine starts"
+  - F10: "Error — Machine validation fails: reject with structured error before any tool executes"
 touchpoints:
-  - T1: "StitchBoundaryAdapter — assignment validation and result packaging (prd001-tool-system-components-interfaces R1, R4)"
-  - T2: "AgentLoopOrchestrator — loop execution delegation (prd002-trail-lifecycle-state-machine R3)"
-  - T3: "CrumbLedger — execution summary extraction (prd001-tool-system-components-interfaces R5)"
+  - T1: "StitchBoundaryAdapter — assignment validation, Machine loading, and result packaging (prd001-tool-system-components-interfaces R1, R3)"
+  - T2: "Engine — dispatch loop execution until terminal state (prd001-tool-system-components-interfaces R1, R4)"
+  - T3: "CrumbLedger — execution summary and outcome classification extraction (prd001-tool-system-components-interfaces R5)"
 success_criteria:
   - id: S1
-    criterion: A valid assignment envelope produces a structured AgentInvokeResponse with status and execution summary
+    criterion: A valid assignment envelope produces a structured AgentInvokeResponse with outcome classification and execution summary
     traces:
-      - prd001-tool-system-components-interfaces AC4
+      - prd001-tool-system-components-interfaces AC1
   - id: S2
-    criterion: An invalid assignment envelope is rejected before the agentic loop starts
+    criterion: An invalid assignment envelope or invalid Machine is rejected before the Engine dispatch loop starts
     traces:
       - prd001-tool-system-components-interfaces AC1
   - id: S3
-    criterion: The stitch runtime performs no git operations; branch management belongs to the orchestrator
+    criterion: The runtime performs no git operations; branch management belongs to the orchestrator
     traces:
-      - prd001-tool-system-components-interfaces AC6
+      - prd001-tool-system-components-interfaces AC1
 test_suite: test-rel01.0

--- a/docs/specs/use-cases/rel01.1-uc003-hexagonal-runtime-wiring.yaml
+++ b/docs/specs/use-cases/rel01.1-uc003-hexagonal-runtime-wiring.yaml
@@ -9,11 +9,11 @@ flow:
   - F1: "Configure inbound port binding: StitchBoundaryAdapter implements AgentInvokePort"
   - F2: "Configure outbound port bindings: LLMToolAdapter, WorkspaceDiscoveryAdapter, WorkspaceMutationAdapter, ValidationAdapter, StateAuditAdapter implement their respective ports"
   - F3: "Initialize runtime with port bindings; core services receive port references only"
-  - F4: "Execute a loop turn through the wired ports to validate end-to-end data flow"
-  - F5: "Replace one adapter with a test double and verify core behavior is unchanged"
+  - F4: "Execute a dispatch cycle through the wired ports to validate end-to-end data flow"
+  - F5: "Replace one adapter with a test double and verify Engine behavior is unchanged"
 touchpoints:
-  - T1: "AgentLoopOrchestrator — depends on ports only (prd009-hexagonal-ports-and-wiring R1, R2)"
-  - T2: "Port interfaces — LLMInvocationPort, WorkspaceDiscoveryReadPort, WorkspaceMutationPort, ValidationPort, StateAuditPorts (prd009-hexagonal-ports-and-wiring R3)"
+  - T1: "Engine — depends on ports only (prd009-hexagonal-ports-and-wiring R1, R2)"
+  - T2: "Port interfaces — LLMInvocationPort, WorkspaceDiscoveryReadPort, WorkspaceMutationPort, ValidationPort, StateAuditPorts, TracePort (prd009-hexagonal-ports-and-wiring R3)"
 success_criteria:
   - id: S1
     criterion: Core domain services compile and run with port interfaces only, no adapter imports

--- a/docs/specs/use-cases/rel01.3-uc004-comparative-conformance-evaluation.yaml
+++ b/docs/specs/use-cases/rel01.3-uc004-comparative-conformance-evaluation.yaml
@@ -18,10 +18,10 @@ flow:
   - F9: "Identify gaps and map to PRD requirements for future work"
 touchpoints:
   - T1: "StitchBoundaryAdapter — entry interface conformance (prd021-comparative-agent-conformance-baseline R1)"
-  - T2: "AgentLoopOrchestrator — workflow control conformance (prd021-comparative-agent-conformance-baseline R2)"
-  - T3: "InvocationValidator — parser robustness conformance (prd021-comparative-agent-conformance-baseline R3)"
+  - T2: "Engine — workflow control conformance (prd021-comparative-agent-conformance-baseline R2)"
+  - T3: "ToolContractValidator — parser robustness conformance (prd021-comparative-agent-conformance-baseline R3)"
   - T4: "PermissionExecutor — safety and permission conformance (prd021-comparative-agent-conformance-baseline R4)"
-  - T5: "ModelResponseRouter — output routing conformance (prd021-comparative-agent-conformance-baseline R5)"
+  - T5: "Machine — output routing conformance via signal-based transitions (prd021-comparative-agent-conformance-baseline R5)"
   - T6: "ValidationPort — Go diagnostics conformance (prd021-comparative-agent-conformance-baseline R6)"
   - T7: "CrumbLedger — audit quality conformance (prd021-comparative-agent-conformance-baseline R7)"
 success_criteria:


### PR DESCRIPTION
## Summary

Re-aligned the entire docs/ design to reflect 11 agentic design patterns from the BACKGROUND/agentic-design-patterns/ monograph. The imperative AgentLoopOrchestrator control flow model is replaced with a declarative Engine interpreting a YAML Machine, with typed signals, per-state tool scoping, and OpenTelemetry trace instrumentation.

## Changes

- **ARCHITECTURE.yaml**: Rewritten for State Interpreter (Machine, Engine, Registry) and Declarative Agent patterns. Components: Engine, Machine, Registry, ToolContractValidator, TrailManager, StitchBoundaryAdapter, LLMToolAdapter, CrumbLedger, UndoManager, TraceAdapter. 15 design decisions covering all 11 patterns.
- **VISION.yaml**: Rewritten executive_summary, problem, what_this_does, success_criteria for declarative agent thesis.
- **prd001**: Rewritten as Engine, Machine, Registry component definitions with static validation and execution recording.
- **prd002**: Rewritten as Machine state lifecycle with states, signals, transitions, terminal states, and resumption.
- **prd003**: Rewritten for Scoped Toolset pattern — per-state tool visibility, manifest filtering, manifest validation.
- **prd004**: Rewritten as Tool Contract validation — parameter types, emittable signals, undo modes, tool categories.
- **prd005**: Rewritten for Execution Rollback pattern — per-tool Undo, Engine-driven rollback, rollback lifecycle machine, four undo tiers.
- **prd006**: Rewritten for Model Adapter pattern — invoke_llm as boundary tool, PromptAssembler, ProviderAdapter, ResponseParser.
- **prd024**: Rewritten as Outcome Classifier — four-valued taxonomy (Clean, Recovery, Stuck, Divergent), pure classifier function.
- **prd027** (new): Trace Instrumentation — Tracer port, four-type span tree, W3C trace context propagation.
- **prd028** (new): Agent Delegation — non-terminal boundary tools, parent-child separation, three-tier composition.
- **prd029** (new): Approval Gate — signal triplet, checkpoint-based suspension, resume and rollback paths.
- **prd030** (new): Runtime Probe — MonitorRecorder, read-plane, control-plane, LifecycleTool, LoopHooks.
- **Interface specs**: if001 (invoke_llm boundary tool), if002 (Engine invoke), if010 (Machine data structure) updated.
- **Use cases**: uc001, uc002 rewritten for Engine dispatch cycle; uc003, uc004 touchpoints updated.
- **SPECIFICATIONS.yaml**: Added prd027-prd030 to prd_index, updated prd024 title.
- **road-map.yaml**: Release 01.0 renamed to Declarative Core; added use cases for trace instrumentation, agent delegation, approval gate, runtime probe.
- **component-catalog.yaml**: Rewritten with declarative components, updated wiring_map, hexagonal_classification, and ownership_model.

## Stats

- 27 PRDs (24 existing + 3 new), 4 use cases, 3 test suites, 5 releases
- 0 uncovered R-items, 0 semantic model validation errors
- 11 schema validation errors (pre-existing semantic_model false positives from PR #8)

## Test plan

- [x] mage analyze runs with 0 new errors
- [x] All PRDs include semantic_model with observe/reason/produce
- [x] All PRDs have complete acceptance criteria with R-item traceability
- [x] All use cases reference Engine, Machine, Registry instead of AgentLoopOrchestrator
- [x] component-catalog lists declarative components only

Closes #5