### PR TITLE
GH-3: Rename PRD to SRD across the codebase

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Press is in specification phase. No application code has been generated yet.
 
 ## Methodology
 
-Specification-driven development. The chain runs VISION → ARCHITECTURE → PRDs
+Specification-driven development. The chain runs VISION → ARCHITECTURE → SRDs
 → use cases → test suites → code. All specifications are YAML. Cobbler's
 measure phase reads the specs and proposes tasks. Stitch executes them.
 
@@ -68,7 +68,7 @@ press/
 │   ├── SPECIFICATIONS.yaml    Cross-reference index
 │   ├── road-map.yaml          Release schedule
 │   ├── specs/
-│   │   ├── product-requirements/   24 PRDs
+│   │   ├── product-requirements/   24 SRDs
 │   │   ├── use-cases/              4 use cases (spec complete)
 │   │   ├── test-suites/            2 test suites (pending)
 │   │   ├── interfaces/             10 interface contracts

--- a/docs/ARCHITECTURE.yaml
+++ b/docs/ARCHITECTURE.yaml
@@ -99,8 +99,8 @@ components:
       - resume from persisted checkpoint
       - classify outcome (Clean, Recovery, Stuck, Divergent) on terminal state
     references:
-      - prd001-tool-system-components-interfaces
-      - prd002-trail-lifecycle-state-machine
+      - srd001-tool-system-components-interfaces
+      - srd002-trail-lifecycle-state-machine
 
   - name: Machine
     provided_by: runtime/data
@@ -115,7 +115,7 @@ components:
       - declare $tool slots for dynamic dispatch (model-selected tools)
       - support per-state tool scoping
     references:
-      - prd002-trail-lifecycle-state-machine
+      - srd002-trail-lifecycle-state-machine
 
   - name: Registry
     provided_by: runtime/tools
@@ -130,8 +130,8 @@ components:
       - factory dispatch for tool construction (exec, rest, builtin, boundary)
       - signal set registration for static Machine validation
     references:
-      - prd001-tool-system-components-interfaces
-      - prd004-tool-invocation-validation
+      - srd001-tool-system-components-interfaces
+      - srd004-tool-invocation-validation
 
   - name: ToolContractValidator
     provided_by: runtime/invocation
@@ -146,7 +146,7 @@ components:
       - parameter type matching
       - undo mode declaration enforcement
     references:
-      - prd004-tool-invocation-validation
+      - srd004-tool-invocation-validation
 
   - name: TrailManager
     provided_by: runtime/core
@@ -156,7 +156,7 @@ components:
       - complete and abandon transitions
       - enforce terminal-state restrictions
     references:
-      - prd002-trail-lifecycle-state-machine
+      - srd002-trail-lifecycle-state-machine
 
   - name: StitchBoundaryAdapter
     provided_by: runtime/integration
@@ -187,8 +187,8 @@ components:
       - signal emission (LLMResponded, BudgetExceeded)
       - per-provider instrumentation and metrics
     references:
-      - prd006-stitch-essential-toolset
-      - prd004-tool-invocation-validation
+      - srd006-stitch-essential-toolset
+      - srd004-tool-invocation-validation
 
   - name: CrumbLedger
     provided_by: runtime/ledger
@@ -200,8 +200,8 @@ components:
       - rejection crumb writes for validation failures
       - undo crumb linkage to original crumbs
     references:
-      - prd001-tool-system-components-interfaces
-      - prd005-undo-and-compensation
+      - srd001-tool-system-components-interfaces
+      - srd005-undo-and-compensation
 
   - name: UndoManager
     provided_by: runtime/undo
@@ -214,7 +214,7 @@ components:
       - per-tool Undo dispatch with recorded result
       - unresolved side-effect reporting
     references:
-      - prd005-undo-and-compensation
+      - srd005-undo-and-compensation
 
   - name: TraceAdapter
     provided_by: runtime/observability
@@ -227,7 +227,7 @@ components:
       - span correlation by trail id and execution id
       - structured logging fallback via log/slog
     references:
-      - prd027-trace-instrumentation
+      - srd027-trace-instrumentation
 
 design_decisions:
   - id: 1
@@ -409,7 +409,7 @@ design_decisions:
     benefits:
       - orchestrator gets a typed outcome, not a raw status code
       - recovery decisions are data-driven, not heuristic
-      - degradation detection (prd024) is one signal within the taxonomy
+      - degradation detection (srd024) is one signal within the taxonomy
     alternatives_rejected:
       - binary success/failure (no recovery or divergence signal)
       - ad hoc status strings (no taxonomy, no static analysis)
@@ -488,7 +488,7 @@ project_structure:
     role: Canonical runtime component inventory with dependencies and sequencing.
   - path: docs/interfaces/
     role: Component-level request and response contracts for implementation.
-  - path: docs/specs/product-requirements/
+  - path: docs/specs/software-requirements/
     role: Numbered requirements and acceptance criteria for each runtime subsystem.
   - path: docs/specs/use-cases/
     role: Tracer-bullet execution flows mapped to architecture touchpoints.
@@ -499,7 +499,7 @@ implementation_status:
   current_focus: Re-align design docs to declarative agent patterns before code implementation.
   progress:
     - item: Vision and architecture YAML rewritten for State Interpreter and Declarative Agent patterns.
-    - item: PRDs being updated to reflect Engine, Machine, Registry, and Tool Contract.
+    - item: SRDs being updated to reflect Engine, Machine, Registry, and Tool Contract.
     - item: Use-case and test-suite specs pending alignment with declarative architecture.
 
 related_documents:

--- a/docs/SPECIFICATIONS.yaml
+++ b/docs/SPECIFICATIONS.yaml
@@ -9,7 +9,7 @@ overview: |
   language-specific rules, conventions, and build commands at invocation time. The runtime
   itself is implemented in Go and links with the crumbs library.
 
-  This document indexes all PRDs, use cases, and test suites in the project and shows how they
+  This document indexes all SRDs, use cases, and test suites in the project and shows how they
   relate. For goals and boundaries, see VISION.yaml. For components and interfaces, see
   ARCHITECTURE.yaml.
 
@@ -40,119 +40,119 @@ roadmap_summary:
     use_cases_total: 0
     status: not_started
 
-prd_index:
-  - id: prd001-tool-system-components-interfaces
+srd_index:
+  - id: srd001-tool-system-components-interfaces
     title: Tool System Components and Interfaces
     summary: Define canonical runtime components, interface contracts, and sequence responsibilities for tool execution control.
-    path: specs/product-requirements/prd001-tool-system-components-interfaces.yaml
-  - id: prd002-trail-lifecycle-state-machine
+    path: specs/software-requirements/srd001-tool-system-components-interfaces.yaml
+  - id: srd002-trail-lifecycle-state-machine
     title: Trail Lifecycle State Machine
     summary: Define trail state transitions, activation guards, and terminal-state enforcement.
-    path: specs/product-requirements/prd002-trail-lifecycle-state-machine.yaml
-  - id: prd003-tool-stash-availability
+    path: specs/software-requirements/srd002-trail-lifecycle-state-machine.yaml
+  - id: srd003-tool-stash-availability
     title: Tool Stash Availability
     summary: Define stash-scoped tool eligibility checks and deny-by-default policy.
-    path: specs/product-requirements/prd003-tool-stash-availability.yaml
-  - id: prd004-tool-invocation-validation
+    path: specs/software-requirements/srd003-tool-stash-availability.yaml
+  - id: srd004-tool-invocation-validation
     title: Tool Invocation Validation
     summary: Define typed decode, semantic validation, and execution pipeline for tool calls.
-    path: specs/product-requirements/prd004-tool-invocation-validation.yaml
-  - id: prd005-undo-and-compensation
+    path: specs/software-requirements/srd004-tool-invocation-validation.yaml
+  - id: srd005-undo-and-compensation
     title: Undo and Compensation
     summary: Define rollback planning, undo mode declaration, and compensation execution.
-    path: specs/product-requirements/prd005-undo-and-compensation.yaml
-  - id: prd006-stitch-essential-toolset
+    path: specs/software-requirements/srd005-undo-and-compensation.yaml
+  - id: srd006-stitch-essential-toolset
     title: Stitch Essential Toolset
     summary: Define the minimal tool surface for specification-to-code generation.
-    path: specs/product-requirements/prd006-stitch-essential-toolset.yaml
-  - id: prd007-file-read-search-and-mutation-safety
+    path: specs/software-requirements/srd006-stitch-essential-toolset.yaml
+  - id: srd007-file-read-search-and-mutation-safety
     title: File Read Search and Mutation Safety
     summary: Define safe file operations with read-before-write and patch-based mutation.
-    path: specs/product-requirements/prd007-file-read-search-and-mutation-safety.yaml
-  - id: prd008-mage-task-execution-and-diagnostics
+    path: specs/software-requirements/srd007-file-read-search-and-mutation-safety.yaml
+  - id: srd008-mage-task-execution-and-diagnostics
     title: Mage Task Execution and Diagnostics
     summary: Define build, lint, and test invocation with structured result capture.
-    path: specs/product-requirements/prd008-mage-task-execution-and-diagnostics.yaml
-  - id: prd009-hexagonal-ports-and-wiring
+    path: specs/software-requirements/srd008-mage-task-execution-and-diagnostics.yaml
+  - id: srd009-hexagonal-ports-and-wiring
     title: Hexagonal Ports and Wiring
     summary: Define port interfaces and adapter classification for dependency inversion.
-    path: specs/product-requirements/prd009-hexagonal-ports-and-wiring.yaml
-  - id: prd010-prompt-library-and-composition
+    path: specs/software-requirements/srd009-hexagonal-ports-and-wiring.yaml
+  - id: srd010-prompt-library-and-composition
     title: Prompt Library and Composition
     summary: Define prompt family taxonomy, composition contracts, and provenance tracking.
-    path: specs/product-requirements/prd010-prompt-library-and-composition.yaml
-  - id: prd011-system-behavior-prompt-family
+    path: specs/software-requirements/srd010-prompt-library-and-composition.yaml
+  - id: srd011-system-behavior-prompt-family
     title: System Behavior Prompt Family
     summary: Define system-level prompt patterns for agent identity and operational constraints.
-    path: specs/product-requirements/prd011-system-behavior-prompt-family.yaml
-  - id: prd012-context-injection-prompt-family
+    path: specs/software-requirements/srd011-system-behavior-prompt-family.yaml
+  - id: srd012-context-injection-prompt-family
     title: Context Injection Prompt Family
     summary: Define prompt patterns for injecting project context and workspace state.
-    path: specs/product-requirements/prd012-context-injection-prompt-family.yaml
-  - id: prd013-tool-policy-prompt-family
+    path: specs/software-requirements/srd012-context-injection-prompt-family.yaml
+  - id: srd013-tool-policy-prompt-family
     title: Tool Policy Prompt Family
     summary: Define prompt patterns for tool usage guidance and constraints.
-    path: specs/product-requirements/prd013-tool-policy-prompt-family.yaml
-  - id: prd014-response-format-prompt-family
+    path: specs/software-requirements/srd013-tool-policy-prompt-family.yaml
+  - id: srd014-response-format-prompt-family
     title: Response Format Prompt Family
     summary: Define prompt patterns for structured output formatting.
-    path: specs/product-requirements/prd014-response-format-prompt-family.yaml
-  - id: prd015-editing-protocol-prompt-family
+    path: specs/software-requirements/srd014-response-format-prompt-family.yaml
+  - id: srd015-editing-protocol-prompt-family
     title: Editing Protocol Prompt Family
     summary: Define prompt patterns for file editing workflows and conventions.
-    path: specs/product-requirements/prd015-editing-protocol-prompt-family.yaml
-  - id: prd016-planning-decomposition-prompt-family
+    path: specs/software-requirements/srd015-editing-protocol-prompt-family.yaml
+  - id: srd016-planning-decomposition-prompt-family
     title: Planning Decomposition Prompt Family
     summary: Define prompt patterns for task planning and work decomposition.
-    path: specs/product-requirements/prd016-planning-decomposition-prompt-family.yaml
-  - id: prd017-error-recovery-prompt-family
+    path: specs/software-requirements/srd016-planning-decomposition-prompt-family.yaml
+  - id: srd017-error-recovery-prompt-family
     title: Error Recovery Prompt Family
     summary: Define prompt patterns for error handling and recovery strategies.
-    path: specs/product-requirements/prd017-error-recovery-prompt-family.yaml
-  - id: prd018-verification-reflection-prompt-family
+    path: specs/software-requirements/srd017-error-recovery-prompt-family.yaml
+  - id: srd018-verification-reflection-prompt-family
     title: Verification Reflection Prompt Family
     summary: Define prompt patterns for self-verification and output reflection.
-    path: specs/product-requirements/prd018-verification-reflection-prompt-family.yaml
-  - id: prd019-memory-summary-prompt-family
+    path: specs/software-requirements/srd018-verification-reflection-prompt-family.yaml
+  - id: srd019-memory-summary-prompt-family
     title: Memory Summary Prompt Family
     summary: Define prompt patterns for context compaction and session memory.
-    path: specs/product-requirements/prd019-memory-summary-prompt-family.yaml
-  - id: prd020-safety-permissions-prompt-family
+    path: specs/software-requirements/srd019-memory-summary-prompt-family.yaml
+  - id: srd020-safety-permissions-prompt-family
     title: Safety Permissions Prompt Family
     summary: Define prompt patterns for permission enforcement and safety constraints.
-    path: specs/product-requirements/prd020-safety-permissions-prompt-family.yaml
-  - id: prd021-comparative-agent-conformance-baseline
+    path: specs/software-requirements/srd020-safety-permissions-prompt-family.yaml
+  - id: srd021-comparative-agent-conformance-baseline
     title: Comparative Agent Conformance Baseline
     summary: Define baseline conformance requirements derived from open-source agent analysis.
-    path: specs/product-requirements/prd021-comparative-agent-conformance-baseline.yaml
-  - id: prd022-exact-match-file-editing
+    path: specs/software-requirements/srd021-comparative-agent-conformance-baseline.yaml
+  - id: srd022-exact-match-file-editing
     title: Exact-Match File Editing
     summary: Define the exact-match editing algorithm using Go stdlib for edit_file.
-    path: specs/product-requirements/prd022-exact-match-file-editing.yaml
-  - id: prd023-fuzzy-match-file-editing
+    path: specs/software-requirements/srd022-exact-match-file-editing.yaml
+  - id: srd023-fuzzy-match-file-editing
     title: Fuzzy-Match File Editing
     summary: Define the optional fuzzy fallback for edit_file using diff-match-patch.
-    path: specs/product-requirements/prd023-fuzzy-match-file-editing.yaml
-  - id: prd024-llm-degradation-detection
+    path: specs/software-requirements/srd023-fuzzy-match-file-editing.yaml
+  - id: srd024-llm-degradation-detection
     title: Outcome Classifier
     summary: Define four-valued convergence taxonomy (Clean, Recovery, Stuck, Divergent) and pure classifier function from execution to type.
-    path: specs/product-requirements/prd024-llm-degradation-detection.yaml
-  - id: prd027-trace-instrumentation
+    path: specs/software-requirements/srd024-llm-degradation-detection.yaml
+  - id: srd027-trace-instrumentation
     title: Trace Instrumentation
     summary: Define Tracer port, four-type OpenTelemetry span tree, and W3C trace context propagation.
-    path: specs/product-requirements/prd027-trace-instrumentation.yaml
-  - id: prd028-agent-delegation
+    path: specs/software-requirements/srd027-trace-instrumentation.yaml
+  - id: srd028-agent-delegation
     title: Agent Delegation
     summary: Define non-terminal boundary tools that compose sub-machines and child agents with independent audit.
-    path: specs/product-requirements/prd028-agent-delegation.yaml
-  - id: prd029-approval-gate
+    path: specs/software-requirements/srd028-agent-delegation.yaml
+  - id: srd029-approval-gate
     title: Approval Gate
     summary: Define checkpoint-based suspension at declared Machine states with resume and rollback paths.
-    path: specs/product-requirements/prd029-approval-gate.yaml
-  - id: prd030-runtime-probe
+    path: specs/software-requirements/srd029-approval-gate.yaml
+  - id: srd030-runtime-probe
     title: Runtime Probe
     summary: Define control-plane server for live state inspection and machine-validated signal injection.
-    path: specs/product-requirements/prd030-runtime-probe.yaml
+    path: specs/software-requirements/srd030-runtime-probe.yaml
 
 use_case_index:
   - id: rel01.0-uc001-agentic-loop-core
@@ -194,30 +194,30 @@ test_suite_index:
     test_case_count: 0
     path: specs/test-suites/ts002-comparative-conformance-baseline.yaml
 
-prd_to_use_case_mapping:
+srd_to_use_case_mapping:
   - use_case: rel01.0-uc001-agentic-loop-core
-    prd: prd002-trail-lifecycle-state-machine
+    srd: srd002-trail-lifecycle-state-machine
     why_required: Exercises trail state transitions during agentic loop execution
     coverage: Partial
   - use_case: rel01.0-uc001-agentic-loop-core
-    prd: prd004-tool-invocation-validation
+    srd: srd004-tool-invocation-validation
     why_required: Validates decode, semantic, and permission checks within loop turns
     coverage: Partial
   - use_case: rel01.0-uc002-orchestrator-stitch-boundary
-    prd: prd001-tool-system-components-interfaces
+    srd: srd001-tool-system-components-interfaces
     why_required: Exercises component boundaries at the orchestrator integration point
     coverage: Partial
   - use_case: rel01.1-uc003-hexagonal-runtime-wiring
-    prd: prd009-hexagonal-ports-and-wiring
+    srd: srd009-hexagonal-ports-and-wiring
     why_required: Validates port and adapter classification with runtime wiring
     coverage: Partial
   - use_case: rel01.3-uc004-comparative-conformance-evaluation
-    prd: prd021-comparative-agent-conformance-baseline
+    srd: srd021-comparative-agent-conformance-baseline
     why_required: Measures agent runtime against open-source conformance baselines
     coverage: Partial
 
 coverage_gaps: |
-  Most PRDs are not yet referenced by use cases. Releases 01.1, 02.0, and 03.0 have
+  Most SRDs are not yet referenced by use cases. Releases 01.1, 02.0, and 03.0 have
   pending use cases that need YAML files authored. Test suites have zero test cases.
   The specification graph will be completed during the measure phase once cobbler-scaffold
   generates task proposals from the roadmap.
@@ -232,6 +232,6 @@ coverage_gaps: |
   loop_trail_id, orchestrator polls cupboard for outcome. Loop trail uses crumbs
   branches_from link to connect to the orchestrator's assignment crumb.
 
-  prd022 (exact-match file editing) ships in release 01.1 with zero external dependencies.
-  prd023 (fuzzy-match file editing) ships in a later release behind a configuration flag
+  srd022 (exact-match file editing) ships in release 01.1 with zero external dependencies.
+  srd023 (fuzzy-match file editing) ships in a later release behind a configuration flag
   and adds github.com/sergi/go-diff as the sole external dependency.

--- a/docs/VISION.yaml
+++ b/docs/VISION.yaml
@@ -96,27 +96,27 @@ implementation_phases:
   - phase: "01.0"
     focus: Declarative core — Machine, Engine, Registry
     deliverables: |
-      ARCHITECTURE.yaml, VISION.yaml, prd001-tool-system-components-interfaces
-      (Engine, Machine, Registry), prd002-trail-lifecycle-state-machine
-      (Machine state lifecycle), prd004-tool-invocation-validation
+      ARCHITECTURE.yaml, VISION.yaml, srd001-tool-system-components-interfaces
+      (Engine, Machine, Registry), srd002-trail-lifecycle-state-machine
+      (Machine state lifecycle), srd004-tool-invocation-validation
       (Tool Contract validation).
   - phase: "01.1"
     focus: Toolset scoping, model adapter, and trace instrumentation
     deliverables: |
-      prd003-tool-stash-availability (Scoped Toolset), prd006-stitch-essential-toolset
-      (Model Adapter), prd007-file-read-search-and-mutation-safety,
-      prd008-mage-task-execution-and-diagnostics, prd009-hexagonal-ports-and-wiring,
-      prd010-prompt-library-and-composition, prd027-trace-instrumentation,
+      srd003-tool-stash-availability (Scoped Toolset), srd006-stitch-essential-toolset
+      (Model Adapter), srd007-file-read-search-and-mutation-safety,
+      srd008-mage-task-execution-and-diagnostics, srd009-hexagonal-ports-and-wiring,
+      srd010-prompt-library-and-composition, srd027-trace-instrumentation,
       interface specifications.
   - phase: "02.0"
     focus: Execution rollback and agent delegation
     deliverables: |
-      prd005-undo-and-compensation (per-tool Undo), prd028-agent-delegation,
-      prd029-approval-gate.
+      srd005-undo-and-compensation (per-tool Undo), srd028-agent-delegation,
+      srd029-approval-gate.
   - phase: "03.0"
     focus: Outcome classification, runtime probe, and validation
     deliverables: |
-      prd024-llm-degradation-detection (Outcome Classifier), prd030-runtime-probe,
+      srd024-llm-degradation-detection (Outcome Classifier), srd030-runtime-probe,
       use-case specifications, test-suite specifications.
 
 risks:

--- a/docs/constitutions/design.yaml
+++ b/docs/constitutions/design.yaml
@@ -1,7 +1,7 @@
 # Design Constitution
 #
 # This constitution governs the design/architecting phase: creating VISION,
-# ARCHITECTURE, PRDs, use cases, test suites, and other documentation. It is
+# ARCHITECTURE, SRDs, use cases, test suites, and other documentation. It is
 # scaffolded into consuming projects so Claude knows how to write specs that
 # match the project's documentation standards.
 
@@ -10,13 +10,13 @@ articles:
     title: Specification-driven development
     rule: |
       Specifications are the source of truth. Code serves specifications, not
-      the other way around. No implementation code before the PRD and use case
+      the other way around. No implementation code before the SRD and use case
       exist. No implementation issue before a test suite exists for its use case.
 
   - id: D2
     title: YAML-first for structured docs
     rule: |
-      Use YAML for structured documents (VISION, ARCHITECTURE, PRDs, use cases,
+      Use YAML for structured documents (VISION, ARCHITECTURE, SRDs, use cases,
       test suites). Use markdown for prose-heavy guidelines and specifications
       summaries. YAML is machine-readable by design.
 
@@ -30,9 +30,9 @@ articles:
   - id: D4
     title: Traceability
     rule: |
-      Every PRD traces to VISION and ARCHITECTURE. Every use case traces to
-      PRDs (via touchpoints). Every test suite traces to use cases (via the
-      traces field). Code traces to PRDs via commit messages and comments.
+      Every SRD traces to VISION and ARCHITECTURE. Every use case traces to
+      SRDs (via touchpoints). Every test suite traces to use cases (via the
+      traces field). Code traces to SRDs via commit messages and comments.
 
   - id: D5
     title: Roadmap-driven releases
@@ -97,7 +97,7 @@ document_types:
     purpose: |
       States what the project is, why it exists, how success is measured, and
       what it is not. Orients stakeholders, new contributors, and downstream
-      docs (ARCHITECTURE, PRDs).
+      docs (ARCHITECTURE, SRDs).
 
   architecture:
     location: docs/ARCHITECTURE.yaml
@@ -116,11 +116,11 @@ document_types:
     purpose: |
       Describes how the system is built: components, interfaces, protocols,
       data flow, design decisions. Bridge between vision (what and why) and
-      PRDs (numbered requirements).
+      SRDs (numbered requirements).
 
-  prd:
-    location: "docs/specs/product-requirements/prd[NNN]-[feature-name].yaml"
-    format_rule: prd-format
+  srd:
+    location: "docs/specs/software-requirements/srd[NNN]-[feature-name].yaml"
+    format_rule: srd-format
     required_fields:
       - id
       - title
@@ -134,12 +134,25 @@ document_types:
       requirement_groups: "R1, R2, R3, ..."
       requirement_items: "R1.1, R1.2, R2.1, ..."
       requirement_id_format: "R{group}.{item} — numeric dotted only (e.g., R1.1, R2.3). Letter suffixes (R2a) are not valid and are flagged by mage analyze."
-      acceptance_criteria_ids: "AC1, AC2, AC3, ... (sequential within each PRD)"
+      requirement_weight: |
+        Each R-item may optionally specify a weight indicating implementation
+        complexity. Weight is a positive integer with no upper bound, default 1.
+        The measure agent uses weights to batch requirements into tasks that fit
+        within the max_weight_per_task budget. Two YAML formats are supported:
+
+        Simple (weight defaults to 1):
+          - R1.1: Must accept -f flag
+
+        Weighted:
+          - R6.1:
+              text: Must scan each input line for known timestamp patterns
+              weight: 3
+      acceptance_criteria_ids: "AC1, AC2, AC3, ... (sequential within each SRD)"
     acceptance_criteria_schema:
       description: |
         Each acceptance criterion is a structured object linking a checkable
         statement to the requirement items it validates. Every R-item in the
-        PRD must appear in at least one AC's traces list.
+        SRD must appear in at least one AC's traces list.
       fields:
         - id: "AC1, AC2, ... (sequential)"
         - criterion: "Checkable statement (the prose text)"
@@ -175,18 +188,18 @@ document_types:
     success_criteria_schema:
       description: |
         Each success criterion is a structured object linking a checkable
-        outcome to the PRD acceptance criteria it exercises. The traces field
-        references PRD AC IDs using the format prdNNN-name ACN.
+        outcome to the SRD acceptance criteria it exercises. The traces field
+        references SRD AC IDs using the format srdNNN-name ACN.
       fields:
         - id: "S1, S2, ... (sequential)"
         - criterion: "Checkable outcome statement"
-        - traces: "List of PRD AC IDs (e.g., [prd001-orchestrator-core AC1])"
+        - traces: "List of SRD AC IDs (e.g., [srd001-orchestrator-core AC1])"
       example: |
         success_criteria:
           - id: S1
             criterion: New(config) returns a non-nil *Orchestrator
             traces:
-              - prd001-orchestrator-core AC2
+              - srd001-orchestrator-core AC2
     purpose: |
       Describes a concrete usage of the architecture. One end-to-end path
       (tracer bullet) through the system. Leads to a proof-of-concept or demo.
@@ -196,15 +209,15 @@ document_types:
     location: "docs/specs/test-suites/test-rel-[release-id].yaml"
     format_rule: test-case-format
     required_fields:
-      - id (matching filename, e.g. test-rel01.0)
+      - id (matching filename, e.g. test-rel-01.0)
       - title
       - release (release ID this suite covers)
       - traces (list of use case IDs covered by this suite)
       - test_cases (list organized by use case sub-sections, each with name, inputs, expected outputs)
     traces_format: |
       The traces field in test_cases can reference three kinds of IDs:
-        - PRD R-item IDs: prdNNN-name RN.N (e.g., prd001-orchestrator-core R1.1)
-        - PRD AC IDs: prdNNN-name ACN (e.g., prd001-orchestrator-core AC1)
+        - SRD R-item IDs: srdNNN-name RN.N (e.g., srd001-orchestrator-core R1.1)
+        - SRD AC IDs: srdNNN-name ACN (e.g., srd001-orchestrator-core AC1)
         - UC S-item IDs: relNN.N-ucNNN-name SN (e.g., rel01.0-uc001-orchestrator-initialization S1)
     purpose: |
       Groups test cases for a full release. Each use case in the release appears
@@ -225,8 +238,46 @@ document_types:
       - references
     purpose: |
       Documents conventions, practices, and patterns above the code and
-      architecture. Not PRDs (no numbered requirements). Not architecture (no
+      architecture. Not SRDs (no numbered requirements). Not architecture (no
       component descriptions).
+
+  interface_specification:
+    location: "docs/interfaces/ifc-[kebab-case-name].yaml"
+    format_rule: interface-specification-format
+    required_fields:
+      - id (matches filename without extension)
+      - name (must match ARCHITECTURE.yaml interface entry)
+      - summary (one to three sentences)
+    optional_fields:
+      - "data_structures (list: name, description, fields as typed field list)"
+      - "operations (list: name, description, parameters, returns)"
+      - announcements (list of events the interface emits)
+      - references (list of SRD or use case IDs)
+    purpose: |
+      Standalone, language-agnostic interface contract. Uses typed field
+      lists for data structures and typed parameter/return lists for
+      operations. Pure YAML throughout, consistent with D2. Replaces
+      Go-specific signatures inlined in ARCHITECTURE.yaml with
+      machine-parseable definitions. See eng10-interface-specifications for
+      the full format and examples.
+
+  semantic_model:
+    location: "docs/specs/semantic-models/[domain]-[behavior].yaml"
+    format_rule: semantic-model-format
+    required_fields:
+      - name (pattern {domain}-{behavior})
+      - version (semver MAJOR.MINOR.PATCH)
+      - "data_sources (list with connector and queries)"
+      - "features (list with name, source, extraction)"
+      - "algorithm (type, parameters, logic)"
+      - output_format (type and fields)
+    purpose: |
+      Declarative behavioral specification for one agent capability. Declares
+      what the agent observes (data_sources), how it interprets observations
+      (features), how it reasons (algorithm), and what it produces
+      (output_format). Mutable layer between the SRD (stable architecture) and
+      generated code (implementation). See docs/constitutions/semantic-model.yaml
+      for the full ten-article schema (SM1-SM10).
 
   specification:
     location: docs/SPECIFICATIONS.yaml
@@ -236,16 +287,16 @@ document_types:
       - title
       - overview (multi-line text)
       - "roadmap_summary (list: version, name, use_cases_done, use_cases_total, status)"
-      - "prd_index (list: id, title, summary, path)"
+      - "srd_index (list: id, title, summary, path)"
       - "use_case_index (list: id, title, release, status, test_suite, path)"
       - "test_suite_index (list: id, title, traces, test_case_count, path)"
-      - "prd_to_use_case_mapping (list: use_case, prd, why_required, coverage)"
+      - "srd_to_use_case_mapping (list: use_case, srd, why_required, coverage)"
       - coverage_gaps (list or multi-line text)
     optional_fields:
       - traceability_diagram (Mermaid as multi-line string)
       - references
     purpose: |
-      Human-readable summary tying together PRDs, use cases, test suites, and
+      Human-readable summary tying together SRDs, use cases, test suites, and
       roadmap into one navigable page. Does not duplicate content; summarizes
       and shows relationships. Regenerate when any artifact changes.
 
@@ -287,10 +338,12 @@ document_types:
       Do not estimate; read the files.
 
 naming_conventions:
-  prd: "prd[NNN]-[feature-name].yaml (e.g., prd001-cupboard-core.yaml)"
+  srd: "srd[NNN]-[feature-name].yaml (e.g., srd001-cupboard-core.yaml)"
   use_case: "rel[NN].[N]-uc[NNN]-[short-name].yaml (e.g., rel01.0-uc001-cupboard-lifecycle.yaml)"
-  test_suite: "test-[use-case-id].yaml (e.g., test-rel01.0-uc001-cupboard-lifecycle.yaml)"
+  test_suite: "test-rel-[release-id].yaml (e.g., test-rel-01.0.yaml)"
   engineering_guideline: "eng[NN]-[short-name].yaml (e.g., eng01-git-integration.yaml)"
+  interface_specification: "ifc-[kebab-case-name].yaml (e.g., ifc-generation-lifecycle.yaml)"
+  semantic_model: "[domain]-[behavior].yaml (e.g., cobbler-measure.yaml, edge-compute-capacity-predictor.yaml)"
   architecture: "ARCHITECTURE.yaml"
   vision: "VISION.yaml"
   specification: "SPECIFICATIONS.yaml"
@@ -305,10 +358,11 @@ writing_guidelines:
 traceability_model:
   vision: Goals and boundaries
   architecture: Components and interfaces (implements vision)
-  prds: Numbered requirements (architecture points to PRDs for detail)
+  srds: Numbered requirements (architecture points to SRDs for detail)
   use_cases: Tracer bullets (exercise architecture components via touchpoints)
   test_suites: Validation (validate use case success criteria)
-  code: Implementation (traces to PRDs via commit messages)
+  semantic_models: Behavioral specs (declarative what-the-agent-does, output_format aligns with SRD IFunctional outputs)
+  code: Implementation (traces to SRDs via commit messages and to semantic models via algorithm logic)
 
 completeness_checklists:
   vision:
@@ -324,13 +378,13 @@ completeness_checklists:
   architecture:
     - id matches project name
     - overview.summary states what the system does and core insight
-    - interfaces list data structures, operations, announcements; link to PRD for full spec
-    - components list each major component with responsibility; link to PRD or use case
+    - interfaces list data structures, operations, announcements; link to SRD for full spec
+    - components list each major component with responsibility; link to SRD or use case
     - design_decisions are numbered with decision statement and benefits
     - project_structure shows directory paths and roles
     - File saved as ARCHITECTURE.yaml in docs/
 
-  prd:
+  srd:
     - id matches filename without extension
     - problem states what we solve and why it matters
     - goals are numbered (G1, G2, ...) and measurable
@@ -339,13 +393,15 @@ completeness_checklists:
     - non_goals define what is out of scope
     - acceptance_criteria are structured objects with id, criterion, and traces
     - Every R-item appears in at least one AC's traces list
-    - File saved as prd[NNN]-[feature-name].yaml
+    - Interactive requirements (prompting, confirmation) specify exact prompt text, accepted input values, case sensitivity, retry behavior on invalid input, and default behavior when stdin is not a terminal
+    - File saved as srd[NNN]-[feature-name].yaml
 
   use_case:
     - id matches filename without extension
     - flow steps are numbered (F1, F2, ...), end-to-end, map to real components
     - touchpoints are numbered (T1, T2, ...) and list interfaces, components, protocols
-    - success_criteria are structured objects with id, criterion, and traces to PRD AC IDs
+    - touchpoints that cite SRDs must include R-group references (e.g., "srd030-md5sum R1, R2, R3"); bare SRD citations without R-groups break codereadiness computation
+    - success_criteria are structured objects with id, criterion, and traces to SRD AC IDs
     - test_suite references a corresponding test suite ID
     - Test suite YAML exists and traces back to this use case
     - Use case added to appropriate release in road-map.yaml
@@ -353,12 +409,33 @@ completeness_checklists:
 
   test_suite:
     - id matches filename
-    - traces lists at least one use case or PRD requirement
+    - traces lists at least one use case or SRD requirement
     - preconditions describe shared starting state
     - Each test case has name, inputs, expected outputs
     - Inputs use real commands and data
     - Expected outputs are specific and checkable
     - File saved as test-[use-case-id].yaml
+
+  interface_specification:
+    - id matches filename without extension (ifc-[kebab-case-name])
+    - name matches the corresponding ARCHITECTURE.yaml interface entry
+    - summary describes the interface contract in one to three sentences
+    - data_structures use typed field lists (name, type, description, required)
+    - operations have name, description, typed parameters, and typed returns
+    - references list SRD or use case IDs the interface traces to
+    - File saved as ifc-[kebab-case-name].yaml in docs/interfaces/
+
+  semantic_model:
+    - name matches the pattern {domain}-{behavior}
+    - version follows semver (MAJOR.MINOR.PATCH)
+    - exactly four top-level sections present (data_sources, features, algorithm, output_format) per SM1
+    - every data source declares a connector type, not an implementation URL or library (SM2)
+    - every feature references at least one data source by id and query name; feature graph is acyclic (SM3)
+    - algorithm declares a named type, parameters, and pseudocode logic (not executable code) (SM4)
+    - output_format aligns with the agent's IFunctional interface in the SRD (SM5)
+    - one coherent behavior per semantic model (SM6)
+    - no prohibitive statements ("do not", "never", "must not") — those belong in constitutions (SM8)
+    - File saved as [domain]-[behavior].yaml in docs/specs/semantic-models/
 
 sections:
   - tag: articles
@@ -377,14 +454,15 @@ sections:
   - tag: document_types
     title: Document Types
     content: |
-      Seven document types are defined: vision, architecture, PRD, use case,
-      test suite, engineering guideline, and specification. Each has a canonical
-      location, format rule, required fields, and optional fields.
+      Eleven document types are defined: vision, architecture, SRD, use case,
+      test suite, engineering guideline, interface specification, semantic
+      model, specification, roadmap, and generation run report. Each has a
+      canonical location, format rule, required fields, and optional fields.
   - tag: naming_conventions
     title: Naming Conventions
     content: |
       File names follow strict patterns per document type (e.g.,
-      prd[NNN]-[feature].yaml, rel[NN].[N]-uc[NNN]-[name].yaml). Use lowercase
+      srd[NNN]-[feature].yaml, rel[NN].[N]-uc[NNN]-[name].yaml). Use lowercase
       kebab-case throughout.
   - tag: writing_guidelines
     title: Writing Guidelines
@@ -396,8 +474,8 @@ sections:
     title: Traceability Model
     content: |
       Every artifact traces through the chain: vision goals → architecture
-      components → PRD requirements → use case tracer bullets → test suite
-      validation → code implementation.
+      components → SRD requirements → use case tracer bullets → test suite
+      validation → semantic model behavior → code implementation.
   - tag: completeness_checklists
     title: Completeness Checklists
     content: |

--- a/docs/constitutions/execution.yaml
+++ b/docs/constitutions/execution.yaml
@@ -8,16 +8,16 @@ articles:
   - id: E1
     title: Specification-first
     rule: |
-      Code must correspond to existing PRDs and architecture. Read the PRDs and
+      Code must correspond to existing SRDs and architecture. Read the SRDs and
       ARCHITECTURE sections listed in Required Reading before writing code. Do
       not invent interfaces, types, or patterns not described in those docs.
 
   - id: E2
     title: Traceability
     rule: |
-      Commit messages must mention which PRDs (or aspects) are implemented.
-      Example: "Implement X (prd-feature-name R6-R7)". Where useful (package or
-      top-of-file comments), list the implemented PRDs.
+      Commit messages must mention which SRDs (or aspects) are implemented.
+      Example: "Implement X (srd-feature-name R6-R7)". Where useful (package or
+      top-of-file comments), list the implemented SRDs.
 
   - id: E3
     title: No scope creep
@@ -40,6 +40,50 @@ articles:
       Every item in Acceptance Criteria must be verified. Run tests if the
       criteria require it. Do not skip any criterion.
 
+  - id: E6
+    title: Non-goals enforcement
+    rule: |
+      Features listed in a SRD's non_goals must not be implemented. Do not
+      parse, accept, or act on flags, options, or behaviors that appear in
+      non_goals. If a requirement references a non_goal feature, treat it as
+      a specification error and skip the requirement with a TODO comment
+      citing the conflict.
+
+  - id: E7
+    title: Skip ambiguous requirements
+    rule: |
+      If a requirement is too vague to implement completely, do not implement
+      it partially. Skip the requirement entirely. Add a TODO comment citing
+      the requirement ID and describing what is missing from the specification.
+      A parsed-but-nonfunctional flag is worse than a missing flag.
+
+  - id: E8
+    title: Function size limit
+    rule: |
+      No function may exceed 40 lines of code. This is a hard limit, not a
+      guideline. If a function exceeds 40 lines, find a seam and split it
+      before the task is considered complete. Common seams: validation logic,
+      formatting logic, I/O operations, and branch-specific handling.
+
+  - id: E9
+    title: File size limit
+    rule: |
+      Each Go source file should stay under 500 lines of production code.
+      When a file exceeds this threshold, split by responsibility: main.go
+      (entry point and arg parsing), format.go (output formatting), and
+      additional files as needed. Test files follow the same split. pkg/
+      packages follow the same 500-line threshold.
+
+  - id: E10
+    title: DRY enforcement
+    rule: |
+      The duplication threshold is two. If you write the same logic twice,
+      extract it into a shared function. Common violations: entry display
+      logic duplicated across output modes, error formatting repeated in
+      multiple functions, path construction logic copied between list and
+      recurse paths. Before writing a function, search for existing code
+      that does the same thing.
+
 coding_standards:
   copyright_header: |
     Every Go file must start with the SPDX copyright header:
@@ -49,7 +93,10 @@ coding_standards:
   never_duplicate_code: |
     Before writing a function, search for existing code that does the same thing.
     When two pieces of code share logic, extract the common part. The threshold
-    is two: if you write the same thing twice, extract it.
+    is two: if you write the same thing twice, extract it. Common violations:
+    entry display logic duplicated across output modes, error formatting repeated
+    in multiple functions, path construction logic copied between list and recurse
+    paths. See article E10.
 
   design_patterns:
     - Strategy: Multiple implementations, caller picks one. Define interface, not if/else ladder.
@@ -68,7 +115,9 @@ coding_standards:
   struct_and_function_design: |
     Each struct represents one concept. Each function does one thing. If a
     function takes more than three parameters, group related parameters into a
-    config struct. If a function exceeds 40 lines, find a seam and split it.
+    config struct. No function may exceed 40 lines — this is a hard limit
+    enforced by article E8. Common seams for splitting: validation, formatting,
+    I/O, and branch-specific handling.
 
   error_handling: |
     Handle errors at the point they occur. Use guard clauses: check err != nil
@@ -88,7 +137,7 @@ coding_standards:
     tests/: Integration tests.
     magefiles/: Build tooling. Flat directory. One file per concern.
 
-    Align package structure to PRD component structure. Each major component
+    Align package structure to SRD component structure. Each major component
     maps to one package. Avoid package names like util, common, helpers.
 
   standard_packages:
@@ -119,28 +168,60 @@ coding_standards:
 
 traceability:
   before_implementing:
-    - Identify related PRDs, ARCHITECTURE, use cases, test suites, guidelines, VISION
+    - Identify related SRDs, ARCHITECTURE, use cases, test suites, guidelines, VISION
     - Read the relevant sections so behavior, data shapes, and contracts are clear
     - Implement so the code conforms to the requirements and design described
 
   commit_message: |
-    Must mention which PRDs (or aspects) are being implemented. Prefer explicit:
-    "Implement X (prd-feature-name, prd-component)" or "Add Y per prd-feature R12".
-    If only parts touched, say so: "Implement operation X (prd-feature R8, R13)".
+    Must mention which SRDs (or aspects) are being implemented. Prefer explicit:
+    "Implement X (srd-feature-name, srd-component)" or "Add Y per srd-feature R12".
+    If only parts touched, say so: "Implement operation X (srd-feature R8, R13)".
 
   code_comments: |
-    At the top of a file or package doc, list implemented PRDs and architecture
+    At the top of a file or package doc, list implemented SRDs and architecture
     sections. Do not repeat this in every function; use file- or package-level
     comments only.
 
   reference_paths:
     - "Architecture: docs/ARCHITECTURE.yaml"
-    - "PRDs: docs/specs/product-requirements/prd*.yaml"
+    - "SRDs: docs/specs/software-requirements/srd*.yaml"
     - "Use cases: docs/specs/use-cases/rel*-uc*-*.yaml"
     - "Test suites (YAML specs): docs/specs/test-suites/test-rel-*.yaml"
     - "Release tests (Go): tests/rel-*/rel-*_test.go"
     - "Engineering guidelines: docs/engineering/eng*.md"
     - "Vision: docs/VISION.yaml"
+
+build_and_test:
+  build_within_module: |
+    Always build and test from within the Go module directory. Do not cd
+    outside the module or create separate Go modules for testing. Use
+    `go build -o bin/<name> ./cmd/<name>/` for cmd/ binaries so outputs
+    land in bin/ (git-ignored). Do not use mage build or mage lint for
+    individual packages — use go build and go vet directly.
+
+  test_planning: |
+    Plan test prerequisites before writing test code. Determine what
+    binaries, fixtures, or reference implementations the tests need.
+    If cmd/ is empty during generation (code not yet written), skip
+    tests that require a built binary — use t.Skip with an explanatory
+    message. For tests that compare against reference binaries (e.g.
+    GNU coreutils), always use exec.LookPath and t.Skip if the
+    reference is not installed.
+
+  negative_tests: |
+    Do not write subtests that intentionally fail the test harness and
+    then fix them afterward. Every test you write must pass on the first
+    run. Use assertions (require.Equal, assert.Error) to check expected
+    error conditions. Use subprocess exec.Command to test exit codes
+    and signal handling rather than calling os.Exit in-process. Never
+    write a test that you expect to fail — if behavior is conditional,
+    use t.Skip or build tags.
+
+  repository_notes: |
+    Files with "collision" in the name are test fixtures for hash
+    collision testing — do not delete or modify them. Utilities that
+    write to stdout must install a SIGPIPE handler (signal.Notify +
+    signal.Reset) so piped output does not cause a broken-pipe crash.
 
 session_completion:
   git_managed_externally: true  # Do NOT run any git commands
@@ -172,10 +253,11 @@ sections:
   - tag: articles
     title: Core Principles
     content: |
-      Six principles govern the stitch phase: specification-first development,
+      Ten principles govern the stitch phase: specification-first development,
       commit traceability, no scope creep, session completion via
-      orchestrator-managed git, quality gate enforcement, and prohibition of
-      magic test values.
+      orchestrator-managed git, quality gate enforcement, non-goals enforcement,
+      skip-on-ambiguity, function size limits, file size limits, and DRY
+      enforcement.
   - tag: coding_standards
     title: Coding Standards
     content: |
@@ -186,8 +268,8 @@ sections:
   - tag: traceability
     title: Traceability
     content: |
-      Before implementing, read the specified PRDs and architecture sections.
-      Commit messages must cite PRDs. Add a PRD list to file or package comments
+      Before implementing, read the specified SRDs and architecture sections.
+      Commit messages must cite SRDs. Add a SRD list to file or package comments
       where useful.
   - tag: session_completion
     title: Session Completion

--- a/docs/constitutions/go-style.yaml
+++ b/docs/constitutions/go-style.yaml
@@ -26,6 +26,28 @@ duplication: |
   share fields. Use helper functions to share behavior. Use interfaces to share
   contracts. The threshold is two: if you write the same thing twice, extract it.
 
+implementation_strategy: |
+  Write all source files before running any build or test commands. Plan the
+  full implementation (types, functions, imports) mentally, then write each
+  file in dependency order. Only run `go build` or `go vet` after all files
+  are written. This minimizes turns and avoids incremental compile-fix loops
+  that re-send the entire prompt context on each iteration.
+
+  When writing a new cmd/ utility:
+  1. Read the SRD and existing pkg/ contracts.
+  2. Write main.go with all flag parsing, logic, and error handling in one pass.
+  3. Write the test file with all test cases in one pass.
+  4. Run `go vet` once to verify compilation.
+  5. Run `go test` once to verify behavior.
+  6. Fix any issues in a single edit pass.
+
+  Common Go compilation errors to avoid on first write:
+  - Missing imports: always include fmt, os, io, strings when doing I/O.
+  - Unused imports: do not import packages speculatively.
+  - Type mismatches: check pkg/ contract signatures before calling.
+  - Missing error handling: every function that returns error must be checked.
+  - Unused variables: do not declare variables before they are needed.
+
 design_patterns:
   - name: Strategy
     description: |
@@ -208,7 +230,7 @@ project_structure: |
   enforced by Go's internal/ directory convention. This rule applies uniformly to
   packages under pkg/ and to top-level internal/ packages alike.
 
-  Align package structure to PRD component structure. Each major component maps
+  Align package structure to SRD component structure. Each major component maps
   to one package. Avoid package names like util, common, helpers. Name packages
   by domain: storage, auth, config.
 
@@ -362,6 +384,7 @@ code_review_checklist:
   - "No init() function performs I/O or returns an error."
   - "No panic() is reachable from a runtime condition or user-provided input."
   - "Typed iota enums are used for any fixed set of integer values."
+  - "All source files are written before running build or test commands — no incremental compile-fix loops."
 
 sections:
   - tag: copyright_header
@@ -374,6 +397,13 @@ sections:
       Search for existing code before writing a new function. Extract shared
       logic at the two-occurrence threshold — if you write the same thing twice,
       extract it.
+  - tag: implementation_strategy
+    title: Implementation Strategy
+    content: |
+      Write all source files before running any build or test commands. Plan
+      the full implementation, write each file in dependency order, then
+      compile and test once. This avoids incremental compile-fix loops that
+      waste turns re-sending the entire prompt context.
   - tag: design_patterns
     title: Design Patterns
     content: |

--- a/docs/constitutions/interface.yaml
+++ b/docs/constitutions/interface.yaml
@@ -1,0 +1,135 @@
+# Interface Constitution
+#
+# This constitution governs the definition, naming, and traceability of
+# interfaces in the architecture and SRDs. It is scaffolded into consuming
+# projects so Claude knows how to write well-formed interface specifications
+# and how SRDs reference interfaces.
+
+articles:
+  - id: I1
+    title: Interface specifications live in docs/interfaces/
+    rule: |
+      Every interface has a specification file in docs/interfaces/. The
+      specification file is the authoritative contract: it defines data
+      structures with typed fields and operations with typed parameters and
+      return values. See eng10-interface-specifications for the full format.
+
+      ARCHITECTURE.yaml declares each interface in its interfaces section
+      with a name, summary, and a spec_file field pointing to the
+      specification file. The ARCHITECTURE.yaml entry is a discovery point
+      and summary; the specification file is the source of truth.
+
+  - id: I2
+    title: Required interface fields
+    rule: |
+      Every interface entry in ARCHITECTURE.yaml must have a name, a
+      summary, and a spec_file. The name is a short, unique identifier
+      (e.g., "Orchestrator and Config", "Prompt Templates"). The summary
+      describes what the interface provides in one to three sentences. The
+      spec_file is the path to the specification file in docs/interfaces/.
+      Optional fields are data_structures (list of type names with brief
+      descriptions) and operations (list of method or function signatures).
+
+      Interface specification files in docs/interfaces/ must have id, name,
+      and summary. Optional fields are data_structures (with typed field
+      lists), operations (with typed parameters and returns), announcements,
+      and references.
+
+  - id: I3
+    title: Naming conventions
+    rule: |
+      Interface names use title case with spaces (e.g., "Generation
+      Lifecycle", "Issue Tracker"). Names must be unique within
+      ARCHITECTURE.yaml. Abbreviations are permitted when the abbreviation
+      is standard in the domain (e.g., "OOD" for object-oriented design),
+      but must be explained in the summary on first use.
+
+      Specification file names use kebab case matching the interface name:
+      ifc-[kebab-case-name].yaml (e.g., ifc-generation-lifecycle.yaml).
+
+  - id: I4
+    title: SRD interface references
+    rule: |
+      SRDs may declare interface relationships using two optional fields:
+      implemented_by and used_by. Both are lists of interface names that
+      must resolve to entries in ARCHITECTURE.yaml's interfaces section.
+
+      implemented_by declares that the SRD's requirements define the
+      implementation of the named interface. The SRD's package_contract
+      exports correspond to the interface's operations.
+
+      used_by declares that the SRD's implementation consumes the named
+      interface. The SRD depends on the interface being available but does
+      not define it.
+
+      A single SRD may appear in both lists for different interfaces. An
+      interface may be implemented by one SRD and used by many.
+
+  - id: I5
+    title: Port and adapter semantics
+    rule: |
+      Interfaces follow the ports and adapters pattern. The specification
+      file in docs/interfaces/ is the port: it defines the contract without
+      specifying implementation. ARCHITECTURE.yaml is the discovery index
+      that points to ports via spec_file. SRDs that list the interface in
+      implemented_by are adapters: they provide a concrete implementation
+      of the port.
+
+      This separation means changing an adapter (rewriting a SRD's
+      implementation) does not change the port (the specification file).
+      Consumers that reference the interface via used_by depend on the
+      port, not the adapter. Analysis enforces that every referenced
+      interface name resolves to a declared port.
+
+      The port contract is defined in the specification file using typed
+      field lists for data structures and typed parameter/return lists for
+      operations.
+
+  - id: I6
+    title: Interface traceability
+    rule: |
+      The traceability chain for interfaces runs: ARCHITECTURE.yaml
+      (declares the interface with spec_file) -> specification file in
+      docs/interfaces/ (defines the contract) -> SRD implemented_by
+      (provides the implementation) -> SRD used_by (consumes the
+      interface). Analysis validates both directions: every name in
+      implemented_by and used_by must match an interface name in
+      ARCHITECTURE.yaml. Broken references fail the analysis check.
+
+      Specification files include a references field listing SRD and use
+      case IDs that the interface traces to, completing the bidirectional
+      link.
+
+sections:
+  - tag: articles
+    title: Core Principles
+    content: |
+      Six principles govern interface specifications: interfaces live in
+      docs/interfaces/ as standalone specification files referenced from
+      ARCHITECTURE.yaml via spec_file (I1), required ARCHITECTURE.yaml
+      fields are name, summary, and spec_file (I2), names use title case
+      and specification files use kebab case (I3), SRDs reference
+      interfaces via implemented_by and used_by (I4), specification files
+      are the ports in ports-and-adapters semantics (I5), and traceability
+      runs from architecture through specification files through SRDs (I6).
+  - tag: structure
+    title: Interface Structure
+    content: |
+      An interface entry in ARCHITECTURE.yaml is a YAML mapping with five
+      fields: name (required), summary (required), spec_file (required),
+      data_structures (optional list), and operations (optional list). SRDs
+      reference interfaces by name using implemented_by and used_by string
+      lists.
+
+      Specification files in docs/interfaces/ use typed field lists for
+      data structures and typed parameter/return lists for operations.
+      See eng10-interface-specifications for the full format.
+  - tag: validation
+    title: Analysis Validation
+    content: |
+      The mage analyze target validates interface references. Every entry
+      in a SRD's implemented_by and used_by lists must match the name
+      field of an interface in ARCHITECTURE.yaml. Unresolved references
+      are reported as errors. Missing or empty interface lists are not
+      errors; the fields are optional. Analyze validates that spec_file
+      paths point to existing files.

--- a/docs/constitutions/issue-format.yaml
+++ b/docs/constitutions/issue-format.yaml
@@ -1,0 +1,225 @@
+# Issue Format Constitution
+#
+# Formal YAML schema for issue descriptions produced by the measure phase
+# and consumed by the stitch phase. Referenced by the measure prompt (to
+# tell Claude what format to produce) and used by stitch (to validate what
+# it reads back).
+
+schema:
+  description: |
+    Every issue description must be a valid YAML document conforming to this
+    schema. The stitch agent parses the description as YAML to extract
+    required_reading, files, requirements, and acceptance_criteria.
+
+  required_fields:
+    - deliverable_type
+    - required_reading
+    - files
+    - requirements
+    - acceptance_criteria
+
+  optional_fields:
+    - format_rule
+    - required_sections
+    - design_decisions
+
+yaml_rules:
+  - rule: All strings containing colons, commas, or special YAML characters must be quoted.
+    example_bad: "- R1: Implement feature: core"
+    example_good: '- "R1: Implement feature: core"'
+
+  - rule: List items are YAML mappings, not bare strings, when they have sub-fields.
+    example_bad: "- Use table accessor pattern"
+    example_good: |
+      - id: D1
+        text: Use table accessor pattern
+
+  - rule: Use ASCII dashes (--) not Unicode em dashes or en dashes.
+    example_bad: "Flag interactions — especially combined flags"
+    example_good: "Flag interactions -- especially combined flags"
+
+  - rule: Requirements, design decisions, and acceptance criteria are all mappings with id and text fields.
+    example_bad: "- Use singleton pattern"
+    example_good: |
+      - id: D1
+        text: Use singleton pattern
+
+field_specs:
+  deliverable_type:
+    type: string
+    values: [documentation, code]
+    required: true
+    description: What kind of deliverable this issue produces.
+
+  required_reading:
+    type: list of strings
+    required: true
+    description: |
+      Files the agent must read before starting. Each entry is a file path
+      with an optional parenthetical reason. This is mandatory for all issues.
+
+  files:
+    type: list of mappings
+    required: true
+    sub_fields:
+      path:
+        type: string
+        required: true
+        description: Absolute path from repo root.
+      action:
+        type: string
+        required: true
+        values: [create, modify]
+      note:
+        type: string
+        required: false
+        description: Brief purpose of this file change.
+
+  requirements:
+    type: list of mappings
+    required: true
+    sub_fields:
+      id:
+        type: string
+        required: true
+        description: "Sequential ID: R1, R2, R3, ..."
+      text:
+        type: string
+        required: true
+        description: What needs to be built or written. Be specific and actionable.
+
+  design_decisions:
+    type: list of mappings
+    required: false
+    sub_fields:
+      id:
+        type: string
+        required: true
+        description: "Sequential ID: D1, D2, D3, ..."
+      text:
+        type: string
+        required: true
+        description: The decision text.
+
+  acceptance_criteria:
+    type: list of mappings
+    required: true
+    sub_fields:
+      id:
+        type: string
+        required: true
+        description: "Sequential ID: AC1, AC2, AC3, ..."
+      text:
+        type: string
+        required: true
+        description: Checkable outcome. Must be verifiable without ambiguity.
+
+  format_rule:
+    type: string
+    required: false
+    description: |
+      For documentation issues only. The rule file that governs the output
+      format (e.g., srd-format, use-case-format).
+
+  required_sections:
+    type: list of strings
+    required: false
+    description: |
+      For documentation issues only. Sections the document must contain.
+
+examples:
+  code_issue: |
+    deliverable_type: code
+
+    required_reading:
+      - docs/specs/software-requirements/srd003-crumbs-interface.yaml
+      - pkg/types/cupboard.go
+
+    files:
+      - path: pkg/types/crumb.go
+        action: create
+        note: Crumb struct, Filter type
+      - path: internal/sqlite/crumbs.go
+        action: create
+        note: CrumbTable implementation
+
+    requirements:
+      - id: R1
+        text: Implement CrumbTable interface per srd003-crumbs-interface
+      - id: R2
+        text: Add, Get, Archive, Purge, Fetch operations
+      - id: R3
+        text: Property operations (Set/Get/Clear)
+
+    design_decisions:
+      - id: D1
+        text: Use table accessor pattern from srd001-cupboard-core
+      - id: D2
+        text: Filter as map[string]any per SRD
+
+    acceptance_criteria:
+      - id: AC1
+        text: All CrumbTable operations implemented
+      - id: AC2
+        text: Tests pass for each operation
+      - id: AC3
+        text: Errors match SRD error types
+
+  documentation_issue: |
+    deliverable_type: documentation
+    format_rule: srd-format
+
+    required_reading:
+      - docs/ARCHITECTURE.yaml (components section)
+      - docs/specs/software-requirements/srd001-cupboard-core.yaml
+
+    files:
+      - path: docs/specs/software-requirements/srd-feature-name.yaml
+        action: create
+
+    required_sections:
+      - "Problem: explain the problem and why it matters"
+      - "Goals: G1 ..., G2 ..."
+      - "Requirements: R1.1 ..., R1.2 ..."
+      - "Non-Goals: what is out of scope"
+      - "Acceptance Criteria: checkable outcomes"
+
+    requirements:
+      - id: R1
+        text: Write SRD covering all identified requirements
+      - id: R2
+        text: Include acceptance criteria for each requirement
+
+    acceptance_criteria:
+      - id: AC1
+        text: All required sections present
+      - id: AC2
+        text: File saved as srd-feature-name.yaml
+      - id: AC3
+        text: Requirements numbered and specific
+
+sections:
+  - tag: schema
+    title: Issue Schema
+    content: |
+      Each issue description is a YAML document with five required fields:
+      deliverable_type, required_reading, files, requirements, and
+      acceptance_criteria. Optional fields include design_decisions and
+      format_rule.
+  - tag: yaml_rules
+    title: YAML Formatting Rules
+    content: |
+      Use multi-line block literals (|) for prose. Keys are lowercase with
+      underscores. Avoid unnecessary quoting. Each requirement and acceptance
+      criterion is a mapping with id and text fields.
+  - tag: field_specs
+    title: Field Specifications
+    content: |
+      Field specifications define the type, allowed values, whether the field is
+      required, and sub-field structure for each issue description field.
+  - tag: examples
+    title: Examples
+    content: |
+      Reference examples for documentation issues and code issues show the full
+      expected YAML structure, including required reading, output paths, format
+      rules, requirements, and acceptance criteria.

--- a/docs/constitutions/planning.yaml
+++ b/docs/constitutions/planning.yaml
@@ -56,29 +56,29 @@ articles:
   - id: P5
     title: Dependency ordering
     rule: |
-      Identify what should be built first and why. PRDs before use cases,
+      Identify what should be built first and why. SRDs before use cases,
       use cases before test suites, test suites before code, foundational code
       before features, libraries before CLI.
 
   - id: P6
     title: Requirement-anchored decomposition
     rule: |
-      Anchor each task to specific PRD requirements by ID (e.g., prd001 R1.1,
-      prd002 R2.3). Include the requirement ID(s) in the task title. Each PRD
+      Anchor each task to specific SRD requirements by ID (e.g., srd001 R1.1,
+      srd002 R2.3). Include the requirement ID(s) in the task title. Each SRD
       requirement maps to exactly one task unless the requirement exceeds the
       line budget, in which case split into implementation and test tasks that
       both reference the same requirement. Do not invent task boundaries that
       cross requirement boundaries. This makes decomposition deterministic:
-      given the same PRD and release, the same set of tasks should be proposed.
+      given the same SRD and release, the same set of tasks should be proposed.
 
   - id: P7
     title: File naming conventions
     rule: |
       Derive file names from the module or feature name established in the
-      PRD or architecture document. Use the existing project naming pattern
+      SRD or architecture document. Use the existing project naming pattern
       (snake_case for Go files, kebab-case for YAML documents). When creating
       a new package, use the name from ARCHITECTURE.yaml. Do not invent novel
-      file names. If the PRD names a component "crumb", the file is crumb.go,
+      file names. If the SRD names a component "crumb", the file is crumb.go,
       not item.go or entity.go. Go packages must name the primary source file
       after the primary exported type, not the package name.
       `testutils/testutils.go` is forbidden; if the primary type is
@@ -102,7 +102,7 @@ articles:
     rule: |
       Code tasks target 5-8 requirements, 5-8 acceptance criteria, and 3-5
       design decisions. Documentation tasks target 2-4 requirements and 3-5
-      acceptance criteria. Each PRD requirement maps to exactly one task
+      acceptance criteria. Each SRD requirement maps to exactly one task
       requirement. Do not inflate counts by splitting a single requirement
       into sub-bullets, and do not deflate counts by merging unrelated
       requirements. If a task falls outside these ranges, re-examine the
@@ -118,7 +118,7 @@ issue_structure:
     required_reading:
       required: true
       description: |
-        Files the agent must read before starting. List PRDs, ARCHITECTURE
+        Files the agent must read before starting. List SRDs, ARCHITECTURE
         sections, existing code, or upstream docs. This is mandatory for all
         issues.
 
@@ -153,7 +153,7 @@ issue_structure:
       format_rule:
         required: true
         description: |
-          The rule file that governs the output format (e.g., prd-format,
+          The rule file that governs the output format (e.g., srd-format,
           use-case-format, test-case-format, architecture-format,
           vision-format, specification-format, engineering-guideline-format).
 
@@ -161,7 +161,7 @@ issue_structure:
         required: false
         description: |
           List of sections the document must contain, per the format rule.
-          For PRD: Problem, Goals, Requirements, Non-Goals, Acceptance Criteria.
+          For SRD: Problem, Goals, Requirements, Non-Goals, Acceptance Criteria.
           For use case: Summary, Actor/trigger, Flow, Success criteria.
 
     deliverable_types:
@@ -170,9 +170,9 @@ issue_structure:
         format_rule: architecture-format
         when: Updating system overview, components, design decisions
 
-      - type: PRD
-        location: "docs/specs/product-requirements/prd[NNN]-[feature-name].yaml"
-        format_rule: prd-format
+      - type: SRD
+        location: "docs/specs/software-requirements/srd[NNN]-[feature-name].yaml"
+        format_rule: srd-format
         when: New or updated product requirements
 
       - type: Use case
@@ -193,7 +193,7 @@ issue_structure:
       - type: Specification
         location: docs/SPECIFICATIONS.md
         format_rule: specification-format
-        when: Summary of PRDs, use cases, test suites, roadmap
+        when: Summary of SRDs, use cases, test suites, roadmap
 
   yaml_quality:
     - Use ASCII dashes (--), not Unicode em dashes or en dashes.
@@ -201,21 +201,21 @@ issue_structure:
 
   code_issues:
     rules:
-      - No PRD-style Problem/Goals/Non-Goals sections in code issues
+      - No SRD-style Problem/Goals/Non-Goals sections in code issues
       - "Requirements focus on implementation: interfaces, operations, tests"
-      - Design decisions reference PRDs and architecture patterns
+      - Design decisions reference SRDs and architecture patterns
       - Acceptance criteria include tests passing and behavior verified
 
 example_documentation_issue: |
   deliverable_type: documentation
-  format_rule: prd-format
+  format_rule: srd-format
 
   required_reading:
     - docs/ARCHITECTURE.yaml (components section)
-    - docs/specs/product-requirements/prd001-cupboard-core.yaml
+    - docs/specs/software-requirements/srd001-cupboard-core.yaml
 
   files:
-    - path: docs/specs/product-requirements/prd-feature-name.yaml
+    - path: docs/specs/software-requirements/srd-feature-name.yaml
       action: create
 
   required_sections:
@@ -229,7 +229,7 @@ example_documentation_issue: |
     - id: AC1
       text: All required sections present
     - id: AC2
-      text: File saved as prd-feature-name.yaml
+      text: File saved as srd-feature-name.yaml
     - id: AC3
       text: Requirements numbered and specific
 
@@ -237,7 +237,7 @@ example_code_issue: |
   deliverable_type: code
 
   required_reading:
-    - docs/specs/product-requirements/prd003-crumbs-interface.yaml
+    - docs/specs/software-requirements/srd003-crumbs-interface.yaml
     - pkg/types/cupboard.go
 
   files:
@@ -253,7 +253,7 @@ example_code_issue: |
 
   requirements:
     - id: R1
-      text: Implement CrumbTable interface per prd003-crumbs-interface
+      text: Implement CrumbTable interface per srd003-crumbs-interface
     - id: R2
       text: Add, Get, Archive, Purge, Fetch operations
     - id: R3
@@ -261,9 +261,9 @@ example_code_issue: |
 
   design_decisions:
     - id: D1
-      text: Use table accessor pattern from prd001-cupboard-core
+      text: Use table accessor pattern from srd001-cupboard-core
     - id: D2
-      text: Filter as map[string]any per PRD
+      text: Filter as map[string]any per SRD
 
   acceptance_criteria:
     - id: AC1
@@ -271,7 +271,7 @@ example_code_issue: |
     - id: AC2
       text: Tests pass for each operation
     - id: AC3
-      text: Errors match PRD error types
+      text: Errors match SRD error types
 
 sections:
   - tag: articles
@@ -291,7 +291,7 @@ sections:
     title: Documentation Issue Example
     content: |
       A worked example shows a properly structured documentation issue for
-      writing a PRD, including required reading, output path, format rule, and
+      writing a SRD, including required reading, output path, format rule, and
       acceptance criteria.
   - tag: example_code_issue
     title: Code Issue Example

--- a/docs/constitutions/semantic-model.yaml
+++ b/docs/constitutions/semantic-model.yaml
@@ -1,0 +1,237 @@
+# Semantic Model Constitution
+#
+# This constitution governs the authoring and validation of semantic models.
+# It is injected into the specification authoring phase so the Generator
+# (human or machine) knows how to produce well-formed, complete behavioral
+# specifications.
+#
+# A semantic model is the mutable behavioral layer of an agent specification.
+# It declares what the agent observes, how it reasons, and what it produces—
+# without prescribing code structure. The SRD defines architecture (stable).
+# The semantic model defines behavior (mutable). Constitutions and guidelines
+# constrain how behavior is implemented (prohibitive). The semantic model
+# declares what behavior IS (declarative).
+
+articles:
+  - id: SM1
+    title: Four mandatory sections
+    rule: |
+      Every semantic model must contain exactly four top-level sections:
+      data_sources, features, algorithm, and output_format. A semantic
+      model that omits any section is incomplete. A semantic model that
+      adds sections beyond these four is overspecified—move the extra
+      content to the SRD, architectural guidelines, or domain knowledge.
+
+      data_sources: what the agent observes (inputs)
+      features: how the agent interprets observations (derived signals)
+      algorithm: how the agent reasons (decision logic)
+      output_format: what the agent produces (outputs)
+
+  - id: SM2
+    title: Data sources are connectors, not implementations
+    rule: |
+      Each data source declares a connector type and a set of named
+      queries. The connector type names an interface or protocol—not a
+      library, endpoint URL, or implementation class. Queries declare
+      parameters and return types using domain types, not language-specific
+      types.
+
+      Good:
+        connector: INetworkState
+        queries:
+          - name: site_capacity
+            parameters: [site_id]
+            returns: {compute_available: float, memory_available: float}
+
+      Bad:
+        connector: "http://10.0.1.5:8080/api/v2"
+        queries:
+          - name: get_capacity
+            parameters: ["string siteId"]
+            returns: "json.RawMessage"
+
+      The semantic model specifies what data the agent needs, not where
+      or how it fetches it. Binding data sources to concrete endpoints
+      happens at deployment through configuration, not at specification
+      time through the semantic model.
+
+  - id: SM3
+    title: Features derive from data sources
+    rule: |
+      Every feature must reference at least one data source by id and
+      query name using dot notation (e.g., network_state.site_capacity).
+      Features that do not trace to a declared data source are untethered—
+      they claim to observe something the agent has no access to.
+
+      The extraction field describes the derivation in domain language,
+      not in code. It should be readable by a domain expert who does not
+      program. The Generator translates extraction descriptions into code;
+      the semantic model author describes the intent.
+
+      Features may reference other features to build derived signals.
+      Feature references must not form cycles. The dependency graph of
+      features must be a DAG.
+
+  - id: SM4
+    title: Algorithm declares logic, not code
+    rule: |
+      The algorithm section specifies the agent's reasoning as a named
+      type, a parameter set, and a logic block written in structured
+      pseudocode or domain language.
+
+      The type field names the reasoning pattern (e.g.,
+      threshold_with_trend, gap_ordered_task_generation,
+      ensemble_prediction). Types should be reusable across semantic
+      models—they name a family of algorithms, not a specific
+      implementation.
+
+      The parameters field declares the tunable knobs of the algorithm.
+      Parameters are the primary target of runtime configuration changes—
+      a threshold change should not require a specification delta if the
+      parameter is already declared.
+
+      The logic block is pseudocode, not executable code. It describes
+      the decision flow using feature names and domain concepts. The
+      Generator reads the logic block to understand the intended behavior
+      and produces the implementation. If the logic block is precise
+      enough to be executable, it is overspecified—it has become code
+      in disguise.
+
+  - id: SM5
+    title: Output format matches the functional interface
+    rule: |
+      The output_format section must align with the agent's IFunctional
+      interface as declared in the SRD. Every field in the output format
+      must correspond to a return type or response structure in the
+      functional interface.
+
+      If the semantic model produces outputs that IFunctional cannot
+      express, either the semantic model is wrong (specifying behavior
+      the architecture does not support) or the SRD needs a delta (the
+      architecture must grow to support the new behavior). This cross-
+      reference between semantic model and SRD is what makes specification
+      layers a graph, not a stack.
+
+  - id: SM6
+    title: One semantic model per behavior
+    rule: |
+      Each semantic model specifies one coherent behavior—one
+      observation-reasoning-output pipeline. An agent that performs
+      multiple behaviors (e.g., capacity prediction AND fault diagnosis)
+      has multiple semantic models, not one large one.
+
+      Semantic models are composed at the specification level. The
+      Specification Selector assembles the set of semantic models an
+      agent instance needs. The SRD defines the architectural slots
+      these models fill. Each slot corresponds to one behavioral
+      capability.
+
+      Splitting behaviors into separate semantic models enables
+      independent evolution. A new fault diagnosis algorithm does not
+      require re-specifying capacity prediction. The evolution pipeline
+      applies the delta to one semantic model without touching others.
+
+  - id: SM7
+    title: Naming and versioning
+    rule: |
+      Every semantic model has a name and a version.
+
+      The name follows the pattern: {domain}-{behavior}
+      Examples: edge-compute-capacity-predictor, transport-fault-diagnoser,
+      cobbler-measure, ran-latency-monitor.
+
+      The version follows semantic versioning (MAJOR.MINOR.PATCH):
+      - MAJOR: breaking changes to data sources or output format
+      - MINOR: new features or algorithm changes (backward compatible)
+      - PATCH: parameter tuning or extraction refinements
+
+      Version changes trigger different evolution responses. A PATCH
+      change may only require regenerating the algorithm implementation.
+      A MAJOR change may require regenerating data connectors, feature
+      extractors, and output formatters—touching multiple components.
+
+  - id: SM8
+    title: Semantic models are declarative, not prohibitive
+    rule: |
+      A semantic model declares what the agent DOES. It does not declare
+      what the agent must NOT do. Prohibitions belong in architectural
+      guidelines or constitutions.
+
+      Declarative (semantic model):
+        "Observe the specification tree, identify unimplemented use cases,
+        order by release priority, decompose into sized tasks."
+
+      Prohibitive (constitution/guideline):
+        "Do NOT propose tasks for implemented use cases."
+        "Do NOT exceed 350 lines per task."
+
+      If a statement in the semantic model begins with "do not," "never,"
+      "must not," or "avoid," it is a constraint and belongs in the
+      architectural guidelines layer. Move it there.
+
+      This separation matters because constraints are stable across
+      instances (every Analyst follows the same coding standards) while
+      behaviors are mutable per instance (each Analyst observes different
+      data and runs different algorithms).
+
+  - id: SM9
+    title: Testability
+    rule: |
+      Every semantic model must be testable through its output format.
+      Given known inputs to data_sources and known feature extractions,
+      the algorithm must produce deterministic or bounded outputs that
+      tests can verify.
+
+      When authoring a semantic model, ask: "Can I write a test that
+      provides mock data sources, runs the algorithm, and checks the
+      output?" If the answer is no, the semantic model is underspecified—
+      it does not declare enough about the algorithm's behavior for the
+      Generator to produce testable code.
+
+      The test suite layer of the agent specification contains tests
+      derived from the semantic model. Each feature should have at least
+      one test validating its extraction. The algorithm should have tests
+      for each branch of its logic. The output format should have tests
+      validating structure and value ranges.
+
+  - id: SM10
+    title: Domain knowledge references, not domain knowledge
+    rule: |
+      The semantic model may reference domain knowledge (ontologies,
+      protocol specs, vendor documentation) but must not embed it.
+      Data source connectors reference interface names defined in
+      domain knowledge. Feature extractions reference domain concepts
+      explained in domain knowledge. The semantic model says "use X";
+      domain knowledge defines what X is.
+
+      This separation keeps the semantic model portable. The same
+      capacity prediction semantic model can apply to different vendors
+      by swapping the domain knowledge binding—different equipment APIs,
+      same behavioral specification.
+
+sections:
+  - tag: articles
+    title: Core Principles
+    content: |
+      Ten principles govern semantic model authoring: four mandatory
+      sections (SM1), connector-based data sources (SM2), traceable
+      features (SM3), declarative algorithms (SM4), interface-aligned
+      outputs (SM5), one behavior per model (SM6), semantic versioning
+      (SM7), declarative not prohibitive (SM8), testability (SM9), and
+      referenced not embedded domain knowledge (SM10).
+  - tag: structure
+    title: Semantic Model Structure
+    content: |
+      A semantic model is a YAML document with four sections:
+      data_sources (inputs), features (derived signals), algorithm
+      (reasoning), and output_format (outputs). Each section has
+      specific structural requirements defined in the articles.
+  - tag: evolution
+    title: Semantic Model Evolution
+    content: |
+      The semantic model is the primary target for agent evolution.
+      Version changes signal the scope of regeneration needed. PATCH
+      changes tune parameters. MINOR changes add features or modify
+      algorithms. MAJOR changes alter inputs or outputs and may
+      require SRD changes. Each semantic model evolves independently
+      of others in the same agent.

--- a/docs/interfaces/if001-llm-tool-adapter.yaml
+++ b/docs/interfaces/if001-llm-tool-adapter.yaml
@@ -285,8 +285,8 @@ acceptance_checks:
 
   traceability:
   requirements:
-    - prd006-stitch-essential-toolset:R2.1
-    - prd006-stitch-essential-toolset:R2.4
-    - prd004-tool-invocation-validation:R4.4
+    - srd006-stitch-essential-toolset:R2.1
+    - srd006-stitch-essential-toolset:R2.4
+    - srd004-tool-invocation-validation:R4.4
   use_cases:
     - rel01.0-uc001-agentic-loop-core

--- a/docs/interfaces/if003-workspace-discovery-read-port.yaml
+++ b/docs/interfaces/if003-workspace-discovery-read-port.yaml
@@ -88,8 +88,8 @@ acceptance_checks:
 
 traceability:
   requirements:
-    - prd006-stitch-essential-toolset:R1.2
-    - prd006-stitch-essential-toolset:R1.3
-    - prd007-file-read-search-and-mutation-safety:R1.1
-    - prd007-file-read-search-and-mutation-safety:R1.2
-    - prd007-file-read-search-and-mutation-safety:R1.3
+    - srd006-stitch-essential-toolset:R1.2
+    - srd006-stitch-essential-toolset:R1.3
+    - srd007-file-read-search-and-mutation-safety:R1.1
+    - srd007-file-read-search-and-mutation-safety:R1.2
+    - srd007-file-read-search-and-mutation-safety:R1.3

--- a/docs/interfaces/if004-workspace-mutation-port.yaml
+++ b/docs/interfaces/if004-workspace-mutation-port.yaml
@@ -80,8 +80,8 @@ acceptance_checks:
 
 traceability:
   requirements:
-    - prd006-stitch-essential-toolset:R1.4
-    - prd007-file-read-search-and-mutation-safety:R2.1
-    - prd007-file-read-search-and-mutation-safety:R2.2
-    - prd007-file-read-search-and-mutation-safety:R2.3
-    - prd007-file-read-search-and-mutation-safety:R3.2
+    - srd006-stitch-essential-toolset:R1.4
+    - srd007-file-read-search-and-mutation-safety:R2.1
+    - srd007-file-read-search-and-mutation-safety:R2.2
+    - srd007-file-read-search-and-mutation-safety:R2.3
+    - srd007-file-read-search-and-mutation-safety:R3.2

--- a/docs/interfaces/if005-validation-port.yaml
+++ b/docs/interfaces/if005-validation-port.yaml
@@ -69,9 +69,9 @@ acceptance_checks:
 
 traceability:
   requirements:
-    - prd006-stitch-essential-toolset:R1.5
-    - prd008-mage-task-execution-and-diagnostics:R1.1
-    - prd008-mage-task-execution-and-diagnostics:R1.2
-    - prd008-mage-task-execution-and-diagnostics:R1.3
-    - prd008-mage-task-execution-and-diagnostics:R4.1
-    - prd008-mage-task-execution-and-diagnostics:R4.2
+    - srd006-stitch-essential-toolset:R1.5
+    - srd008-mage-task-execution-and-diagnostics:R1.1
+    - srd008-mage-task-execution-and-diagnostics:R1.2
+    - srd008-mage-task-execution-and-diagnostics:R1.3
+    - srd008-mage-task-execution-and-diagnostics:R4.1
+    - srd008-mage-task-execution-and-diagnostics:R4.2

--- a/docs/interfaces/if006-state-and-audit-ports.yaml
+++ b/docs/interfaces/if006-state-and-audit-ports.yaml
@@ -40,8 +40,8 @@ acceptance_checks:
 
 traceability:
   requirements:
-    - prd002-trail-lifecycle-state-machine:R1.1
-    - prd002-trail-lifecycle-state-machine:R2.4
-    - prd003-tool-stash-availability:R2.1
-    - prd003-tool-stash-availability:R3.4
-    - prd001-tool-system-components-interfaces:R5.2
+    - srd002-trail-lifecycle-state-machine:R1.1
+    - srd002-trail-lifecycle-state-machine:R2.4
+    - srd003-tool-stash-availability:R2.1
+    - srd003-tool-stash-availability:R3.4
+    - srd001-tool-system-components-interfaces:R5.2

--- a/docs/interfaces/if007-message-history.yaml
+++ b/docs/interfaces/if007-message-history.yaml
@@ -287,8 +287,8 @@ acceptance_checks:
 
 traceability:
   requirements:
-    - prd002-trail-lifecycle-state-machine:R1.1
-    - prd002-trail-lifecycle-state-machine:R2.1
-    - prd019-memory-summary-prompt-family:R1.1
+    - srd002-trail-lifecycle-state-machine:R1.1
+    - srd002-trail-lifecycle-state-machine:R2.1
+    - srd019-memory-summary-prompt-family:R1.1
   use_cases:
     - rel01.0-uc001-agentic-loop-core

--- a/docs/interfaces/if008-tool-schemas.yaml
+++ b/docs/interfaces/if008-tool-schemas.yaml
@@ -4,7 +4,7 @@ component: ToolRegistry
 
 purpose: |
   Define MCP-compatible tool schemas for the eight essential tools listed in
-  prd006-stitch-essential-toolset. Each tool has a name, description, and
+  srd006-stitch-essential-toolset. Each tool has a name, description, and
   inputSchema (JSON Schema object) that the LLM receives to understand
   available actions. The ToolRegistry exposes these schemas to the LLM
   provider via the standard MCP tools list format.
@@ -433,20 +433,20 @@ acceptance_checks:
 
 traceability:
   requirements:
-    - prd006-stitch-essential-toolset:R1.1
-    - prd006-stitch-essential-toolset:R1.2
-    - prd006-stitch-essential-toolset:R1.3
-    - prd006-stitch-essential-toolset:R1.4
-    - prd006-stitch-essential-toolset:R1.5
-    - prd006-stitch-essential-toolset:R2.1
-    - prd006-stitch-essential-toolset:R2.2
-    - prd006-stitch-essential-toolset:R2.3
-    - prd006-stitch-essential-toolset:R4.1
-    - prd006-stitch-essential-toolset:R4.2
-    - prd006-stitch-essential-toolset:R4.3
-    - prd001-tool-system-components-interfaces:R2.1
-    - prd001-tool-system-components-interfaces:R3.1
-    - prd004-tool-invocation-validation:R1.1
-    - prd004-tool-invocation-validation:R3.1
+    - srd006-stitch-essential-toolset:R1.1
+    - srd006-stitch-essential-toolset:R1.2
+    - srd006-stitch-essential-toolset:R1.3
+    - srd006-stitch-essential-toolset:R1.4
+    - srd006-stitch-essential-toolset:R1.5
+    - srd006-stitch-essential-toolset:R2.1
+    - srd006-stitch-essential-toolset:R2.2
+    - srd006-stitch-essential-toolset:R2.3
+    - srd006-stitch-essential-toolset:R4.1
+    - srd006-stitch-essential-toolset:R4.2
+    - srd006-stitch-essential-toolset:R4.3
+    - srd001-tool-system-components-interfaces:R2.1
+    - srd001-tool-system-components-interfaces:R3.1
+    - srd004-tool-invocation-validation:R1.1
+    - srd004-tool-invocation-validation:R3.1
   use_cases:
     - rel01.0-uc001-agentic-loop-core

--- a/docs/interfaces/if009-provider-config.yaml
+++ b/docs/interfaces/if009-provider-config.yaml
@@ -170,7 +170,7 @@ acceptance_checks:
 
 traceability:
   requirements:
-    - prd001-tool-system-components-interfaces:R2.3
-    - prd004-tool-invocation-validation:R1.1
+    - srd001-tool-system-components-interfaces:R2.3
+    - srd004-tool-invocation-validation:R1.1
   use_cases:
     - rel01.0-uc001-agentic-loop-core

--- a/docs/interfaces/if010-agent-loop-state-machine.yaml
+++ b/docs/interfaces/if010-agent-loop-state-machine.yaml
@@ -21,7 +21,7 @@ dependencies:
   - WorkspaceMutationPort
   - MessageHistory (if007)
   - CrumbLedger (if006)
-  - TracePort (prd027)
+  - TracePort (srd027)
 
 types:
   LoopConfig:
@@ -608,9 +608,9 @@ convergence_detection: |
   each other. No existing coding agent (as of 2026-04) detects these — they
   rely entirely on hard limits (max_turns, token budgets).
 
-  Metrics are always collected (prd024 R1). Statistics are always reported
-  in LoopResult (prd024 R2). Degradation signals only trigger early
-  termination when convergence_config.enabled=true (prd024 R4).
+  Metrics are always collected (srd024 R1). Statistics are always reported
+  in LoopResult (srd024 R2). Degradation signals only trigger early
+  termination when convergence_config.enabled=true (srd024 R4).
 
   Five degradation signals:
 
@@ -699,14 +699,14 @@ acceptance_checks:
 
 traceability:
   requirements:
-    - prd001-tool-system-components-interfaces:R4.1
-    - prd002-trail-lifecycle-state-machine:R1.1
-    - prd002-trail-lifecycle-state-machine:R2.1
-    - prd004-tool-invocation-validation:R1.1
-    - prd024-llm-degradation-detection:R1.1
-    - prd024-llm-degradation-detection:R2.1
-    - prd024-llm-degradation-detection:R3.1
-    - prd024-llm-degradation-detection:R4.2
-    - prd024-llm-degradation-detection:R5.1
+    - srd001-tool-system-components-interfaces:R4.1
+    - srd002-trail-lifecycle-state-machine:R1.1
+    - srd002-trail-lifecycle-state-machine:R2.1
+    - srd004-tool-invocation-validation:R1.1
+    - srd024-llm-degradation-detection:R1.1
+    - srd024-llm-degradation-detection:R2.1
+    - srd024-llm-degradation-detection:R3.1
+    - srd024-llm-degradation-detection:R4.2
+    - srd024-llm-degradation-detection:R5.1
   use_cases:
     - rel01.0-uc001-agentic-loop-core

--- a/docs/prompts/measure.yaml
+++ b/docs/prompts/measure.yaml
@@ -4,7 +4,7 @@ role: |
 task: |
   Follow these steps in order. Complete each step before moving to the next. Do NOT explore the filesystem, read files, or run commands unless a step explicitly asks you to. All project information is already provided in the project_context field above.
 
-  1. **Analyze project context** — Review the project_context field above. It contains ALL project documentation: vision, architecture, specifications, roadmap, PRDs, use cases, test suites, engineering guidelines, constitutions, and existing issues. Do NOT read any files — everything you need is inline.
+  1. **Analyze project context** — Review the project_context field above. It contains ALL project documentation: vision, architecture, specifications, roadmap, SRDs, use cases, test suites, engineering guidelines, constitutions, and existing issues. Do NOT read any files — everything you need is inline.
 
   2. **Summarize project state** — Write a brief summary of:
      - What problem this project solves
@@ -32,16 +32,18 @@ constraints: |
   - Components with a provided_by field in ARCHITECTURE.yaml are external infrastructure. Do NOT propose tasks that create or modify files in those components.
   - Do NOT exceed {limit} tasks. If more work is needed, create additional tasks in a future session.
   - Do NOT create tasks larger than {lines_max} lines of production code. Target {lines_min}-{lines_max} lines per task, touching 5-7 files. Split aggressively: a task that creates a struct and implements its methods is two tasks.
-  - Each task must contain at most {max_requirements} PRD sub-requirements (e.g., R1.1, R2.3), not requirement groups. Split any task that would exceed this limit.
+  - Each task must contain at most {max_requirements} SRD sub-requirements (e.g., R1.1, R2.3), not requirement groups. Split any task that would exceed this limit.
   - Each task MUST be independently executable by an agent that has no context beyond the task description and the execution constitution.
   - Do NOT assume the stitch agent has access to your analysis, the existing issues list, or any context from this conversation.
   - Do NOT propose tasks that require human judgment or manual testing. Each task must have checkable acceptance criteria.
-  - Anchor every task to specific PRD requirement IDs (e.g., prd001 R1.1). Include the requirement ID in the task title. Given the same PRD and release, the same tasks should be proposed regardless of how many times this prompt is run.
-  - Order tasks canonically: documentation before code, types before implementations, libraries before consumers, implementation before tests. Break ties by primary file path alphabetically.
-  - Derive file names from PRD/architecture names, not invented names. If the architecture calls a component "crumb", the file is crumb.go.
-  - Do NOT invent design decisions not derived from the PRD or architecture. Derive struct shapes, timeout strategies, file names, and naming conventions from the PRD rather than making arbitrary choices. If the PRD does not specify a detail, omit it from design decisions rather than inventing one.
-  - When a PRD specifies a concrete design choice (e.g., "use a FileExpectation struct", "the main file is difftest.go", "timeout is configurable via context"), copy that choice verbatim into the task's design_decisions. Do not rephrase, generalize, or substitute alternatives. The PRD is the single source of truth for implementation details.
-  - Do NOT vary requirement count between equivalent runs. Each PRD requirement maps to one task requirement. Given the same input, produce the same requirement set. If two runs of this prompt against the same project state would produce different requirements, the decomposition is under-constrained -- tighten it.
+  - Anchor every task to specific SRD requirement IDs (e.g., srd001 R1.1). Include the requirement ID in the task title. Given the same SRD and release, the same tasks should be proposed regardless of how many times this prompt is run.
+  - When requirement_states is present in project_context, only propose tasks for R-items with status "ready". R-items with status "complete", "complete_with_failures", or "skip" must not be re-proposed. If all R-items for the current release are complete or skipped, return an empty list.
+  - Before proposing implementation tasks for a new package, propose a contract task that defines all exported types, interfaces, and function signatures as Go stubs. Title it with the suffix "(contract)" and set its dependency to -1. Implementation tasks for that package must list the contract file in required_reading and depend on the contract task. Do not propose implementation tasks for a package that has no contract task unless the package already exists in source_code.
+  - Order tasks canonically: documentation before code, contracts before implementations, types before consumers, implementation before tests. Break ties by primary file path alphabetically.
+  - Derive file names from SRD/architecture names, not invented names. If the architecture calls a component "crumb", the file is crumb.go.
+  - Do NOT invent design decisions not derived from the SRD or architecture. Derive struct shapes, timeout strategies, file names, and naming conventions from the SRD rather than making arbitrary choices. If the SRD does not specify a detail, omit it from design decisions rather than inventing one.
+  - When a SRD specifies a concrete design choice (e.g., "use a FileExpectation struct", "the main file is difftest.go", "timeout is configurable via context"), copy that choice verbatim into the task's design_decisions. Do not rephrase, generalize, or substitute alternatives. The SRD is the single source of truth for implementation details.
+  - Do NOT vary requirement count between equivalent runs. Each SRD requirement maps to one task requirement. Given the same input, produce the same requirement set. If two runs of this prompt against the same project state would produce different requirements, the decomposition is under-constrained -- tighten it.
   - Do NOT make any tool calls. Return the YAML list directly in your text output.
 
 output_format: |
@@ -58,7 +60,7 @@ output_format: |
 
         required_reading:
           - path/to/file.go (reason this file must be read)
-          - docs/specs/product-requirements/prd001-feature.yaml
+          - docs/specs/software-requirements/srd001-feature.yaml
 
         files:
           - path: pkg/types/example.go
@@ -70,13 +72,13 @@ output_format: |
 
         requirements:
           - id: R1
-            text: Implement ExampleType per prd001-feature R2
+            text: Implement ExampleType per srd001-feature R2
           - id: R2
             text: Add Get and Set operations
 
         design_decisions:
           - id: D1
-            text: Use table accessor pattern from prd001-cupboard-core
+            text: Use table accessor pattern from srd001-cupboard-core
           - id: D2
             text: "Keep implementation in internal/, not pkg/"
 
@@ -110,6 +112,6 @@ output_format: |
 
   The description must be self-contained. All five fields (deliverable_type, required_reading, files, requirements, acceptance_criteria) are required. Each requirement, design_decision, and acceptance_criteria entry is a mapping with `id` and `text` fields. Add design_decisions when the stitch agent must follow specific patterns or architecture constraints.
 
-  When a golden_example field is present in this prompt, it is the authoritative reference for style, granularity, and naming conventions. Match its requirement count range, acceptance criteria density, design decision style, and file naming pattern. Deviate from the golden example only when the PRD explicitly requires a different structure.
+  When a golden_example field is present in this prompt, it is the authoritative reference for style, granularity, and naming conventions. Match its requirement count range, acceptance criteria density, design decision style, and file naming pattern. Deviate from the golden example only when the SRD explicitly requires a different structure.
 
   The orchestrator will parse the YAML from your text output and import the tasks into the issue tracker.

--- a/docs/prompts/stitch.yaml
+++ b/docs/prompts/stitch.yaml
@@ -4,7 +4,7 @@ role: |
 task: |
   Follow these steps in order. Complete each step before moving to the next.
 
-  1. **Review provided context** — The project_context above contains all project documentation and source code. Review the files listed in Required Reading by finding them in the project_context. Only use tools to read files that are NOT already provided above.
+  1. **Review provided context** — The project_context section above already contains all project documentation, SRDs, source code, shared_protocols, and package_contracts inline in this prompt. Review Required Reading files by scrolling up to find them in project_context — do NOT call the Read, Glob, or Grep tools for any file already present above. The only files you may read with tools are files NOT in project_context (e.g. files you are about to create or modify).
 
   2. **Plan approach** — Before writing code, determine:
      - What exists already (interfaces, types, patterns in the source code above)
@@ -17,11 +17,15 @@ task: |
 
 constraints: |
   - Do NOT read any file in the repository to infer style, patterns, or conventions. All style guidance is provided in go_style_constitution above. All source patterns are provided in project_context above. If a file you need is absent from project_context, write it from scratch following go_style_constitution — do not read the filesystem to fill the gap.
-  - Do NOT read files already provided in project_context. They are already inline above.
+  - Do NOT use Read, Glob, or Grep tools on files already in project_context. SRDs, source code, ARCHITECTURE, VISION, shared_protocols, package_contracts — all are inline above. Reading them again wastes a turn and adds no information. Only use Read for files not present in project_context.
   - Do NOT explore the filesystem. Do NOT run ls, find, tree, or similar commands.
   - Do NOT modify files outside the Files to Create/Modify list unless a requirement explicitly demands it.
   - Do NOT use bd or cupboard commands. Task tracking is handled externally.
-  - Do NOT invent interfaces, types, or patterns not described in the source code, Required Reading, or PRDs.
+  - Do NOT invent interfaces, types, or patterns not described in the source code, Required Reading, or SRDs.
   - Do NOT add features, refactoring, or improvements beyond what the requirements specify.
   - Do NOT run any git commands. No git add, git commit, git init, git status, rm .git, or any other git operation. Git is managed externally by the orchestrator. Just write code and verify it compiles and passes tests.
   - When building cmd/ binaries to verify compilation, use `go build -o bin/<name> ./cmd/<name>/` so outputs land in bin/ (which is git-ignored) rather than in the working directory.
+  - When a build or lint step fails, read ALL error and warning messages before making any changes. Fix every reported issue in a single edit pass, then run the build once to verify. Do not fix one issue, rebuild, fix the next — batch all fixes into one round.
+  - When modifying more than 3 locations in the same file, prefer the Write tool (full file replacement) over multiple Edit calls. Each Edit changes the file, invalidating old_string matches for subsequent Edits. Write avoids this by producing the complete file in one call.
+  - The test suite is the acceptance gate. Do not manually run binaries to compare output against reference implementations. Run `go test` and fix any failures. Manual comparison is only warranted when a test fails and the expected behavior is ambiguous.
+  - Complete all code changes before running `go build` or `go test`. Do not compile incrementally after each small edit. Mentally verify imports, types, and function signatures, then build once.

--- a/docs/specs/component-catalog.yaml
+++ b/docs/specs/component-catalog.yaml
@@ -21,7 +21,7 @@ components:
       - Registry for tool resolution
       - CrumbLedger for execution recording
     dependencies:
-      - prd001-tool-system-components-interfaces
+      - srd001-tool-system-components-interfaces
 
   - id: C02
     name: Machine
@@ -35,7 +35,7 @@ components:
     consumes:
       - none
     dependencies:
-      - prd002-trail-lifecycle-state-machine
+      - srd002-trail-lifecycle-state-machine
 
   - id: C03
     name: Registry
@@ -49,8 +49,8 @@ components:
     consumes:
       - none
     dependencies:
-      - prd001-tool-system-components-interfaces
-      - prd004-tool-invocation-validation
+      - srd001-tool-system-components-interfaces
+      - srd004-tool-invocation-validation
 
   - id: C04
     name: ToolContractValidator
@@ -65,7 +65,7 @@ components:
       - Machine for transition references
       - Registry for tool declarations
     dependencies:
-      - prd004-tool-invocation-validation
+      - srd004-tool-invocation-validation
 
   - id: C05
     name: TrailManager
@@ -79,7 +79,7 @@ components:
     consumes:
       - CrumbLedger for transition events
     dependencies:
-      - prd002-trail-lifecycle-state-machine
+      - srd002-trail-lifecycle-state-machine
 
   - id: C06
     name: StitchBoundaryAdapter
@@ -114,8 +114,8 @@ components:
       - Registry for tool declaration
       - CrumbLedger for prompt reference and result metadata persistence
     dependencies:
-      - prd006-stitch-essential-toolset
-      - prd004-tool-invocation-validation
+      - srd006-stitch-essential-toolset
+      - srd004-tool-invocation-validation
 
   - id: C08
     name: CrumbLedger
@@ -129,8 +129,8 @@ components:
     consumes:
       - none
     dependencies:
-      - prd001-tool-system-components-interfaces
-      - prd005-undo-and-compensation
+      - srd001-tool-system-components-interfaces
+      - srd005-undo-and-compensation
 
   - id: C09
     name: UndoManager
@@ -144,7 +144,7 @@ components:
       - CrumbLedger for source crumbs and undo records
       - Engine for rollback dispatch
     dependencies:
-      - prd005-undo-and-compensation
+      - srd005-undo-and-compensation
 
   - id: C10
     name: TraceAdapter
@@ -159,7 +159,7 @@ components:
     consumes:
       - Engine dispatch events
     dependencies:
-      - prd027-trace-instrumentation
+      - srd027-trace-instrumentation
 
 contracts:
   entry_interface:
@@ -266,9 +266,9 @@ minimal_profile:
     - Machine and tool declarations are YAML files.
     - MCP integration is not required for first delivery.
   deferred_or_optional:
-    - Agent Delegation (prd028) as non-terminal boundary tools.
-    - Approval Gate (prd029) as Machine transition.
-    - Runtime Probe (prd030) as control-plane server.
+    - Agent Delegation (srd028) as non-terminal boundary tools.
+    - Approval Gate (srd029) as Machine transition.
+    - Runtime Probe (srd030) as control-plane server.
     - MCPInvokeTool as a configurable integration tool.
 
 status:

--- a/docs/specs/legacy-srd-reconciliation.yaml
+++ b/docs/specs/legacy-srd-reconciliation.yaml
@@ -1,17 +1,17 @@
-id: legacy-prd-reconciliation
-title: Legacy PRD Reconciliation and Cleanup Decisions
+id: legacy-srd-reconciliation
+title: Legacy SRD Reconciliation and Cleanup Decisions
 status: applied
 updated: 2026-03-31
 
 intent: |
-  Remove duplicate normative content from legacy markdown PRDs under prds/
+  Remove duplicate normative content from legacy markdown SRDs under prds/
   and keep docs/specs as the single canonical specification source.
 
 decisions:
   - legacy_file: prds/tool-system-components-interfaces.md
     status: superseded
     canonical_docs:
-      - docs/specs/product-requirements/prd001-tool-system-components-interfaces.yaml
+      - docs/specs/software-requirements/srd001-tool-system-components-interfaces.yaml
       - docs/interfaces/if001-llm-tool-adapter.yaml
       - docs/interfaces/if003-workspace-discovery-read-port.yaml
       - docs/interfaces/if004-workspace-mutation-port.yaml
@@ -22,35 +22,35 @@ decisions:
   - legacy_file: prds/trail-lifecycle-state-machine.md
     status: superseded
     canonical_docs:
-      - docs/specs/product-requirements/prd002-trail-lifecycle-state-machine.yaml
+      - docs/specs/software-requirements/srd002-trail-lifecycle-state-machine.yaml
       - docs/specs/use-cases/uc001-agentic-loop-core.yaml
     action: removed_after_migration
 
   - legacy_file: prds/tool-stash-availability.md
     status: superseded
     canonical_docs:
-      - docs/specs/product-requirements/prd003-tool-stash-availability.yaml
+      - docs/specs/software-requirements/srd003-tool-stash-availability.yaml
       - docs/interfaces/if006-state-and-audit-ports.yaml
     action: removed_after_migration
 
   - legacy_file: prds/tool-invocation-validation.md
     status: superseded
     canonical_docs:
-      - docs/specs/product-requirements/prd004-tool-invocation-validation.yaml
+      - docs/specs/software-requirements/srd004-tool-invocation-validation.yaml
       - docs/specs/use-cases/uc001-agentic-loop-core.yaml
     action: removed_after_migration
 
   - legacy_file: prds/undo-and-compensation.md
     status: superseded
     canonical_docs:
-      - docs/specs/product-requirements/prd005-undo-and-compensation.yaml
+      - docs/specs/software-requirements/srd005-undo-and-compensation.yaml
     action: removed_after_migration
 
   - legacy_file: prds/agent-loop-tool-invocation.md
     status: partially_migrated
     canonical_docs:
-      - docs/specs/product-requirements/prd004-tool-invocation-validation.yaml
-      - docs/specs/product-requirements/prd006-stitch-essential-toolset.yaml
+      - docs/specs/software-requirements/srd004-tool-invocation-validation.yaml
+      - docs/specs/software-requirements/srd006-stitch-essential-toolset.yaml
       - docs/specs/use-cases/uc001-agentic-loop-core.yaml
     unique_residue:
       - response_type_taxonomy_detail
@@ -73,8 +73,8 @@ decisions:
   - legacy_file: prds/glob-tool.md
     status: partially_migrated
     canonical_docs:
-      - docs/specs/product-requirements/prd006-stitch-essential-toolset.yaml
-      - docs/specs/product-requirements/prd007-file-read-search-and-mutation-safety.yaml
+      - docs/specs/software-requirements/srd006-stitch-essential-toolset.yaml
+      - docs/specs/software-requirements/srd007-file-read-search-and-mutation-safety.yaml
       - docs/interfaces/if003-workspace-discovery-read-port.yaml
     unique_residue:
       - backend_adapter_examples_for_rg
@@ -85,8 +85,8 @@ decisions:
     status: reclassified
     canonical_docs:
       - docs/specs/prompt-library/prompt-extraction-and-taxonomy.yaml
-      - docs/specs/product-requirements/prd010-prompt-library-and-composition.yaml
-      - docs/specs/product-requirements/prd021-comparative-agent-conformance-baseline.yaml
+      - docs/specs/software-requirements/srd010-prompt-library-and-composition.yaml
+      - docs/specs/software-requirements/srd021-comparative-agent-conformance-baseline.yaml
       - docs/specs/use-cases/uc004-comparative-conformance-evaluation.yaml
       - docs/specs/test-suites/ts002-comparative-conformance-baseline.yaml
     decision: retain_research_and_extract_normative_baseline

--- a/docs/specs/prompt-library/prompt-extraction-and-taxonomy.yaml
+++ b/docs/specs/prompt-library/prompt-extraction-and-taxonomy.yaml
@@ -324,8 +324,8 @@ maintenance:
     prompt_library_version: v1
     update_policy: |
       Any prompt template change requires version bump and trace update to affected
-      interfaces/use-cases/PRDs.
+      interfaces/use-cases/SRDs.
   traceability_links:
-    - docs/specs/product-requirements/prd010-prompt-library-and-composition.yaml
+    - docs/specs/software-requirements/srd010-prompt-library-and-composition.yaml
     - docs/interfaces/if001-llm-tool-adapter.yaml
     - docs/specs/use-cases/uc001-agentic-loop-core.yaml

--- a/docs/specs/software-requirements/srd001-tool-system-components-interfaces.yaml
+++ b/docs/specs/software-requirements/srd001-tool-system-components-interfaces.yaml
@@ -1,4 +1,4 @@
-id: prd001-tool-system-components-interfaces
+id: srd001-tool-system-components-interfaces
 title: Engine, Machine, and Registry Components
 
 problem: |

--- a/docs/specs/software-requirements/srd002-trail-lifecycle-state-machine.yaml
+++ b/docs/specs/software-requirements/srd002-trail-lifecycle-state-machine.yaml
@@ -1,4 +1,4 @@
-id: prd002-trail-lifecycle-state-machine
+id: srd002-trail-lifecycle-state-machine
 title: Machine State Lifecycle
 
 problem: |

--- a/docs/specs/software-requirements/srd003-tool-stash-availability.yaml
+++ b/docs/specs/software-requirements/srd003-tool-stash-availability.yaml
@@ -1,4 +1,4 @@
-id: prd003-tool-stash-availability
+id: srd003-tool-stash-availability
 title: Scoped Toolset and Per-State Tool Availability
 
 problem: |

--- a/docs/specs/software-requirements/srd004-tool-invocation-validation.yaml
+++ b/docs/specs/software-requirements/srd004-tool-invocation-validation.yaml
@@ -1,4 +1,4 @@
-id: prd004-tool-invocation-validation
+id: srd004-tool-invocation-validation
 title: Tool Contract Validation
 
 problem: |

--- a/docs/specs/software-requirements/srd005-undo-and-compensation.yaml
+++ b/docs/specs/software-requirements/srd005-undo-and-compensation.yaml
@@ -1,4 +1,4 @@
-id: prd005-undo-and-compensation
+id: srd005-undo-and-compensation
 title: Execution Rollback and Per-Tool Undo
 
 problem: |

--- a/docs/specs/software-requirements/srd006-stitch-essential-toolset.yaml
+++ b/docs/specs/software-requirements/srd006-stitch-essential-toolset.yaml
@@ -1,4 +1,4 @@
-id: prd006-stitch-essential-toolset
+id: srd006-stitch-essential-toolset
 title: Essential Toolset and Model Adapter
 
 problem: |

--- a/docs/specs/software-requirements/srd007-file-read-search-and-mutation-safety.yaml
+++ b/docs/specs/software-requirements/srd007-file-read-search-and-mutation-safety.yaml
@@ -1,4 +1,4 @@
-id: prd007-file-read-search-and-mutation-safety
+id: srd007-file-read-search-and-mutation-safety
 title: File Read Search and Mutation Safety
 
 problem: |

--- a/docs/specs/software-requirements/srd008-mage-task-execution-and-diagnostics.yaml
+++ b/docs/specs/software-requirements/srd008-mage-task-execution-and-diagnostics.yaml
@@ -1,4 +1,4 @@
-id: prd008-mage-task-execution-and-diagnostics
+id: srd008-mage-task-execution-and-diagnostics
 title: Mage Task Execution and Diagnostics
 
 problem: |

--- a/docs/specs/software-requirements/srd009-hexagonal-ports-and-wiring.yaml
+++ b/docs/specs/software-requirements/srd009-hexagonal-ports-and-wiring.yaml
@@ -1,4 +1,4 @@
-id: prd009-hexagonal-ports-and-wiring
+id: srd009-hexagonal-ports-and-wiring
 title: Hexagonal Ports Adapters and Wiring
 
 problem: |
@@ -48,9 +48,9 @@ requirements:
     - R5.2: Each driven adapter must pass the contract test suite for its implemented port.
     - R5.3: Contract tests must include positive and failure-path scenarios for deterministic behavior.
   R6:
-    title: PRD Interface References
+    title: SRD Interface References
     items:
-    - R6.1: PRDs must support interface references through implemented_by and used_by fields.
+    - R6.1: SRDs must support interface references through implemented_by and used_by fields.
     - R6.2: implemented_by and used_by references must resolve to existing interface specifications.
     - R6.3: Interface relationship direction must be validated for consistency with adapter classification.
 non_goals:
@@ -75,5 +75,5 @@ acceptance_criteria:
     criterion: Port contract tests are defined and required for all adapter implementations.
     traces: [R5.1, R5.2, R5.3]
   - id: AC6
-    criterion: PRD interface references support implemented_by and used_by with resolution and direction validation rules.
+    criterion: SRD interface references support implemented_by and used_by with resolution and direction validation rules.
     traces: [R6.1, R6.2, R6.3]

--- a/docs/specs/software-requirements/srd010-prompt-library-and-composition.yaml
+++ b/docs/specs/software-requirements/srd010-prompt-library-and-composition.yaml
@@ -1,4 +1,4 @@
-id: prd010-prompt-library-and-composition
+id: srd010-prompt-library-and-composition
 title: Prompt Library and Composition for Stitch Runtime
 
 problem: |

--- a/docs/specs/software-requirements/srd011-system-behavior-prompt-family.yaml
+++ b/docs/specs/software-requirements/srd011-system-behavior-prompt-family.yaml
@@ -1,4 +1,4 @@
-id: prd011-system-behavior-prompt-family
+id: srd011-system-behavior-prompt-family
 title: System Behavior Prompt Family
 problem: |
   Stitch needs a stable system behavior prompt family that defines role, scope,

--- a/docs/specs/software-requirements/srd012-context-injection-prompt-family.yaml
+++ b/docs/specs/software-requirements/srd012-context-injection-prompt-family.yaml
@@ -1,4 +1,4 @@
-id: prd012-context-injection-prompt-family
+id: srd012-context-injection-prompt-family
 title: Context Injection Prompt Family
 problem: |
   Stitch requires structured context injection so each llm.generate call has

--- a/docs/specs/software-requirements/srd013-tool-policy-prompt-family.yaml
+++ b/docs/specs/software-requirements/srd013-tool-policy-prompt-family.yaml
@@ -1,4 +1,4 @@
-id: prd013-tool-policy-prompt-family
+id: srd013-tool-policy-prompt-family
 title: Tool Policy Prompt Family
 problem: |
   Stitch depends on strict tool policy prompts to keep invocation behavior

--- a/docs/specs/software-requirements/srd014-response-format-prompt-family.yaml
+++ b/docs/specs/software-requirements/srd014-response-format-prompt-family.yaml
@@ -1,4 +1,4 @@
-id: prd014-response-format-prompt-family
+id: srd014-response-format-prompt-family
 title: Response Format Prompt Family
 problem: |
   Tool-loop orchestration requires parseable and unambiguous model outputs.

--- a/docs/specs/software-requirements/srd015-editing-protocol-prompt-family.yaml
+++ b/docs/specs/software-requirements/srd015-editing-protocol-prompt-family.yaml
@@ -1,4 +1,4 @@
-id: prd015-editing-protocol-prompt-family
+id: srd015-editing-protocol-prompt-family
 title: Editing Protocol Prompt Family
 problem: |
   Stitch must apply code changes deterministically. Editing protocol prompts

--- a/docs/specs/software-requirements/srd016-planning-decomposition-prompt-family.yaml
+++ b/docs/specs/software-requirements/srd016-planning-decomposition-prompt-family.yaml
@@ -1,4 +1,4 @@
-id: prd016-planning-decomposition-prompt-family
+id: srd016-planning-decomposition-prompt-family
 title: Planning and Decomposition Prompt Family
 problem: |
   Complex tasks require explicit decomposition and branching logic. Without a

--- a/docs/specs/software-requirements/srd017-error-recovery-prompt-family.yaml
+++ b/docs/specs/software-requirements/srd017-error-recovery-prompt-family.yaml
@@ -1,4 +1,4 @@
-id: prd017-error-recovery-prompt-family
+id: srd017-error-recovery-prompt-family
 title: Error Recovery Prompt Family
 problem: |
   Failures in tool calls, API requests, or formatting are inevitable. Stitch

--- a/docs/specs/software-requirements/srd018-verification-reflection-prompt-family.yaml
+++ b/docs/specs/software-requirements/srd018-verification-reflection-prompt-family.yaml
@@ -1,4 +1,4 @@
-id: prd018-verification-reflection-prompt-family
+id: srd018-verification-reflection-prompt-family
 title: Verification and Reflection Prompt Family
 problem: |
   Stitch needs explicit verification prompts to ensure outputs are validated

--- a/docs/specs/software-requirements/srd019-memory-summary-prompt-family.yaml
+++ b/docs/specs/software-requirements/srd019-memory-summary-prompt-family.yaml
@@ -1,4 +1,4 @@
-id: prd019-memory-summary-prompt-family
+id: srd019-memory-summary-prompt-family
 title: Memory and Summary Prompt Family
 problem: |
   Long-running trails exceed context windows and lose continuity without

--- a/docs/specs/software-requirements/srd020-safety-permissions-prompt-family.yaml
+++ b/docs/specs/software-requirements/srd020-safety-permissions-prompt-family.yaml
@@ -1,4 +1,4 @@
-id: prd020-safety-permissions-prompt-family
+id: srd020-safety-permissions-prompt-family
 title: Safety and Permissions Prompt Family
 problem: |
   Stitch executes tools with real workspace effects. Safety and permissions

--- a/docs/specs/software-requirements/srd021-comparative-agent-conformance-baseline.yaml
+++ b/docs/specs/software-requirements/srd021-comparative-agent-conformance-baseline.yaml
@@ -1,4 +1,4 @@
-id: prd021-comparative-agent-conformance-baseline
+id: srd021-comparative-agent-conformance-baseline
 title: Comparative Agent Conformance Baseline
 
 problem: |
@@ -66,7 +66,7 @@ requirements:
 non_goals:
   - Define source-code-level implementation details for each referenced coding-agent.
   - Define vendor or SDK internals outside stitch runtime boundaries.
-  - Replace existing tool, prompt-family, or ports-and-adapters PRDs.
+  - Replace existing tool, prompt-family, or ports-and-adapters SRDs.
 
 acceptance_criteria:
   - id: AC1

--- a/docs/specs/software-requirements/srd022-exact-match-file-editing.yaml
+++ b/docs/specs/software-requirements/srd022-exact-match-file-editing.yaml
@@ -1,10 +1,10 @@
-id: prd022-exact-match-file-editing
+id: srd022-exact-match-file-editing
 title: Exact-Match File Editing
 
 problem: |
   The agent must edit source files by replacing specific text spans. A naive
   implementation risks partial writes, ambiguous matches, or corrupted files.
-  This PRD defines the exact-match editing tier: the primary mechanism where
+  This SRD defines the exact-match editing tier: the primary mechanism where
   old_string must match exactly one location in the file. This tier uses only
   Go standard library (strings.Count, strings.Replace) and has no external
   dependencies. It handles the vast majority of LLM-driven edits where the
@@ -44,7 +44,7 @@ requirements:
     - R4.3: Every edit_file invocation must emit a crumb record with assignment id, trail id, and call id.
 
 non_goals:
-  - Fuzzy or approximate matching (see prd023).
+  - Fuzzy or approximate matching (see srd023).
   - AST-aware or language-specific transformations.
   - Multi-file batch replacement in a single invocation.
   - Regex or glob pattern matching in old_string.

--- a/docs/specs/software-requirements/srd023-fuzzy-match-file-editing.yaml
+++ b/docs/specs/software-requirements/srd023-fuzzy-match-file-editing.yaml
@@ -1,4 +1,4 @@
-id: prd023-fuzzy-match-file-editing
+id: srd023-fuzzy-match-file-editing
 title: Fuzzy-Match File Editing
 
 problem: |
@@ -24,7 +24,7 @@ requirements:
     - R1.1: Fuzzy matching must activate only when exact match returns edit_no_match.
     - R1.2: Fuzzy matching must not activate on edit_ambiguous_match (multiple exact matches).
     - R1.3: Fuzzy matching must be gated by a configuration flag (fuzzy_edit_enabled) that defaults to false.
-    - R1.4: When fuzzy matching is disabled, edit_file must behave identically to prd022 exact-match semantics.
+    - R1.4: When fuzzy matching is disabled, edit_file must behave identically to srd022 exact-match semantics.
   R2:
     title: Algorithm and Thresholds
     items:
@@ -47,8 +47,8 @@ requirements:
   R5:
     title: Atomic Write and Safety
     items:
-    - R5.1: Fuzzy edits must use the same temp-file-and-rename atomic write as exact edits (prd022 R2.1).
-    - R5.2: Fuzzy edits must enforce the same workspace path boundaries as exact edits (prd022 R3.1).
+    - R5.1: Fuzzy edits must use the same temp-file-and-rename atomic write as exact edits (srd022 R2.1).
+    - R5.2: Fuzzy edits must enforce the same workspace path boundaries as exact edits (srd022 R3.1).
     - R5.3: Every fuzzy edit invocation must emit a crumb record that includes the similarity score.
 
 non_goals:

--- a/docs/specs/software-requirements/srd024-llm-degradation-detection.yaml
+++ b/docs/specs/software-requirements/srd024-llm-degradation-detection.yaml
@@ -1,4 +1,4 @@
-id: prd024-llm-degradation-detection
+id: srd024-llm-degradation-detection
 title: Outcome Classifier
 
 problem: |

--- a/docs/specs/software-requirements/srd027-trace-instrumentation.yaml
+++ b/docs/specs/software-requirements/srd027-trace-instrumentation.yaml
@@ -1,4 +1,4 @@
-id: prd027-trace-instrumentation
+id: srd027-trace-instrumentation
 title: Trace Instrumentation
 
 problem: |

--- a/docs/specs/software-requirements/srd028-agent-delegation.yaml
+++ b/docs/specs/software-requirements/srd028-agent-delegation.yaml
@@ -1,4 +1,4 @@
-id: prd028-agent-delegation
+id: srd028-agent-delegation
 title: Agent Delegation
 
 problem: |

--- a/docs/specs/software-requirements/srd029-approval-gate.yaml
+++ b/docs/specs/software-requirements/srd029-approval-gate.yaml
@@ -1,4 +1,4 @@
-id: prd029-approval-gate
+id: srd029-approval-gate
 title: Approval Gate
 
 problem: |

--- a/docs/specs/software-requirements/srd030-runtime-probe.yaml
+++ b/docs/specs/software-requirements/srd030-runtime-probe.yaml
@@ -1,4 +1,4 @@
-id: prd030-runtime-probe
+id: srd030-runtime-probe
 title: Runtime Probe
 
 problem: |

--- a/docs/specs/test-suites/test-rel01.0.yaml
+++ b/docs/specs/test-suites/test-rel01.0.yaml
@@ -10,7 +10,7 @@ test_cases:
   - use_case: rel01.0-uc001-agentic-loop-core
     name: Agentic loop produces one llm.generate crumb per turn
     traces:
-      - prd001-tool-system-components-interfaces AC5
+      - srd001-tool-system-components-interfaces AC5
     inputs:
       - "Assignment envelope with prompt and trail reference"
     expected:
@@ -18,7 +18,7 @@ test_cases:
   - use_case: rel01.0-uc002-orchestrator-stitch-boundary
     name: Stitch boundary returns result without git operations
     traces:
-      - prd001-tool-system-components-interfaces AC4
+      - srd001-tool-system-components-interfaces AC4
     inputs:
       - "Orchestrator assignment envelope"
     expected:

--- a/docs/specs/test-suites/test-rel01.1.yaml
+++ b/docs/specs/test-suites/test-rel01.1.yaml
@@ -9,7 +9,7 @@ test_cases:
   - use_case: rel01.1-uc003-hexagonal-runtime-wiring
     name: Hexagonal ports and adapters conform to dependency inversion
     traces:
-      - prd009-hexagonal-ports-and-wiring AC1
+      - srd009-hexagonal-ports-and-wiring AC1
     inputs:
       - "Runtime component configuration with port and adapter bindings"
     expected:

--- a/docs/specs/test-suites/test-rel01.3.yaml
+++ b/docs/specs/test-suites/test-rel01.3.yaml
@@ -9,8 +9,8 @@ test_cases:
   - use_case: rel01.3-uc004-comparative-conformance-evaluation
     name: Runtime meets conformance baselines
     traces:
-      - prd021-comparative-agent-conformance-baseline AC1
+      - srd021-comparative-agent-conformance-baseline AC1
     inputs:
-      - "Conformance baseline requirements from prd021"
+      - "Conformance baseline requirements from srd021"
     expected:
       - "Runtime meets or exceeds baseline capabilities"

--- a/docs/specs/test-suites/ts001-ports-and-adapters-contracts.yaml
+++ b/docs/specs/test-suites/ts001-ports-and-adapters-contracts.yaml
@@ -50,7 +50,7 @@ success_criteria:
 
 traceability:
   requirements:
-    - prd009-hexagonal-ports-and-wiring:R3.3
-    - prd009-hexagonal-ports-and-wiring:R5.1
-    - prd009-hexagonal-ports-and-wiring:R5.2
-    - prd009-hexagonal-ports-and-wiring:R5.3
+    - srd009-hexagonal-ports-and-wiring:R3.3
+    - srd009-hexagonal-ports-and-wiring:R5.1
+    - srd009-hexagonal-ports-and-wiring:R5.2
+    - srd009-hexagonal-ports-and-wiring:R5.3

--- a/docs/specs/test-suites/ts002-comparative-conformance-baseline.yaml
+++ b/docs/specs/test-suites/ts002-comparative-conformance-baseline.yaml
@@ -3,11 +3,11 @@ title: Comparative Conformance Baseline Test Suite
 
 purpose: |
   Verify that runtime behavior conforms to the comparative baseline requirements
-  defined in PRD021.
+  defined in SRD021.
 
 scope:
   requirements:
-    - prd021-comparative-agent-conformance-baseline
+    - srd021-comparative-agent-conformance-baseline
 
 test_groups:
   - id: TG1
@@ -60,26 +60,26 @@ success_criteria:
 
 traceability:
   requirements:
-    - prd021-comparative-agent-conformance-baseline:R1.1
-    - prd021-comparative-agent-conformance-baseline:R1.2
-    - prd021-comparative-agent-conformance-baseline:R1.3
-    - prd021-comparative-agent-conformance-baseline:R2.1
-    - prd021-comparative-agent-conformance-baseline:R2.2
-    - prd021-comparative-agent-conformance-baseline:R2.3
-    - prd021-comparative-agent-conformance-baseline:R3.1
-    - prd021-comparative-agent-conformance-baseline:R3.2
-    - prd021-comparative-agent-conformance-baseline:R3.3
-    - prd021-comparative-agent-conformance-baseline:R4.1
-    - prd021-comparative-agent-conformance-baseline:R4.2
-    - prd021-comparative-agent-conformance-baseline:R4.3
-    - prd021-comparative-agent-conformance-baseline:R5.1
-    - prd021-comparative-agent-conformance-baseline:R5.2
-    - prd021-comparative-agent-conformance-baseline:R5.3
-    - prd021-comparative-agent-conformance-baseline:R6.1
-    - prd021-comparative-agent-conformance-baseline:R6.2
-    - prd021-comparative-agent-conformance-baseline:R6.3
-    - prd021-comparative-agent-conformance-baseline:R7.1
-    - prd021-comparative-agent-conformance-baseline:R7.2
-    - prd021-comparative-agent-conformance-baseline:R8.1
-    - prd021-comparative-agent-conformance-baseline:R8.2
-    - prd021-comparative-agent-conformance-baseline:R8.3
+    - srd021-comparative-agent-conformance-baseline:R1.1
+    - srd021-comparative-agent-conformance-baseline:R1.2
+    - srd021-comparative-agent-conformance-baseline:R1.3
+    - srd021-comparative-agent-conformance-baseline:R2.1
+    - srd021-comparative-agent-conformance-baseline:R2.2
+    - srd021-comparative-agent-conformance-baseline:R2.3
+    - srd021-comparative-agent-conformance-baseline:R3.1
+    - srd021-comparative-agent-conformance-baseline:R3.2
+    - srd021-comparative-agent-conformance-baseline:R3.3
+    - srd021-comparative-agent-conformance-baseline:R4.1
+    - srd021-comparative-agent-conformance-baseline:R4.2
+    - srd021-comparative-agent-conformance-baseline:R4.3
+    - srd021-comparative-agent-conformance-baseline:R5.1
+    - srd021-comparative-agent-conformance-baseline:R5.2
+    - srd021-comparative-agent-conformance-baseline:R5.3
+    - srd021-comparative-agent-conformance-baseline:R6.1
+    - srd021-comparative-agent-conformance-baseline:R6.2
+    - srd021-comparative-agent-conformance-baseline:R6.3
+    - srd021-comparative-agent-conformance-baseline:R7.1
+    - srd021-comparative-agent-conformance-baseline:R7.2
+    - srd021-comparative-agent-conformance-baseline:R8.1
+    - srd021-comparative-agent-conformance-baseline:R8.2
+    - srd021-comparative-agent-conformance-baseline:R8.3

--- a/docs/specs/use-cases/rel01.0-uc001-agentic-loop-core.yaml
+++ b/docs/specs/use-cases/rel01.0-uc001-agentic-loop-core.yaml
@@ -21,32 +21,32 @@ flow:
   - F12: "Error — Machine validation fails at load time: reject invocation before any tool executes"
   - F13: "Error — invoke_llm times out or fails: BudgetExceeded or error signal routed by Machine"
 touchpoints:
-  - T1: "StitchBoundaryAdapter — assignment envelope validation and Engine startup (prd001-tool-system-components-interfaces R1, R3)"
-  - T2: "Engine — dispatch cycle interpreting Machine transitions (prd001-tool-system-components-interfaces R1, R4)"
-  - T3: "TrailManager — execution trail creation and activation (prd002-trail-lifecycle-state-machine R4)"
-  - T4: "Registry — tool name resolution and signal set validation (prd001-tool-system-components-interfaces R3, R4)"
-  - T5: "LLMToolAdapter — invoke_llm boundary tool with prompt assembly and provider invocation (prd006-stitch-essential-toolset R2)"
-  - T6: "CrumbLedger — execution crumb persistence per dispatch cycle (prd001-tool-system-components-interfaces R5)"
-  - T7: "Machine — transition table with states, signals, and terminal states (prd002-trail-lifecycle-state-machine R1, R2)"
+  - T1: "StitchBoundaryAdapter — assignment envelope validation and Engine startup (srd001-tool-system-components-interfaces R1, R3)"
+  - T2: "Engine — dispatch cycle interpreting Machine transitions (srd001-tool-system-components-interfaces R1, R4)"
+  - T3: "TrailManager — execution trail creation and activation (srd002-trail-lifecycle-state-machine R4)"
+  - T4: "Registry — tool name resolution and signal set validation (srd001-tool-system-components-interfaces R3, R4)"
+  - T5: "LLMToolAdapter — invoke_llm boundary tool with prompt assembly and provider invocation (srd006-stitch-essential-toolset R2)"
+  - T6: "CrumbLedger — execution crumb persistence per dispatch cycle (srd001-tool-system-components-interfaces R5)"
+  - T7: "Machine — transition table with states, signals, and terminal states (srd002-trail-lifecycle-state-machine R1, R2)"
 success_criteria:
   - id: S1
     criterion: Exactly one invoke_llm dispatch crumb exists per Engine cycle iteration
     traces:
-      - prd001-tool-system-components-interfaces AC1
+      - srd001-tool-system-components-interfaces AC1
   - id: S2
     criterion: Engine routes signals to transitions via Machine lookup with no ad hoc classification
     traces:
-      - prd001-tool-system-components-interfaces AC1
+      - srd001-tool-system-components-interfaces AC1
   - id: S3
     criterion: Prompt provenance for the dispatch cycle is reconstructable from stash references or crumb attachments
     traces:
-      - prd006-stitch-essential-toolset AC2
+      - srd006-stitch-essential-toolset AC2
   - id: S4
     criterion: Execution trail remains auditable for replay and rollback planning
     traces:
-      - prd002-trail-lifecycle-state-machine AC5
+      - srd002-trail-lifecycle-state-machine AC5
   - id: S5
     criterion: Engine classifies outcome on terminal state and returns result to orchestrator without git operations
     traces:
-      - prd001-tool-system-components-interfaces AC1
+      - srd001-tool-system-components-interfaces AC1
 test_suite: test-rel01.0

--- a/docs/specs/use-cases/rel01.0-uc002-orchestrator-stitch-boundary.yaml
+++ b/docs/specs/use-cases/rel01.0-uc002-orchestrator-stitch-boundary.yaml
@@ -18,20 +18,20 @@ flow:
   - F9: "Error — invalid assignment envelope: reject with structured error before Engine starts"
   - F10: "Error — Machine validation fails: reject with structured error before any tool executes"
 touchpoints:
-  - T1: "StitchBoundaryAdapter — assignment validation, Machine loading, and result packaging (prd001-tool-system-components-interfaces R1, R3)"
-  - T2: "Engine — dispatch loop execution until terminal state (prd001-tool-system-components-interfaces R1, R4)"
-  - T3: "CrumbLedger — execution summary and outcome classification extraction (prd001-tool-system-components-interfaces R5)"
+  - T1: "StitchBoundaryAdapter — assignment validation, Machine loading, and result packaging (srd001-tool-system-components-interfaces R1, R3)"
+  - T2: "Engine — dispatch loop execution until terminal state (srd001-tool-system-components-interfaces R1, R4)"
+  - T3: "CrumbLedger — execution summary and outcome classification extraction (srd001-tool-system-components-interfaces R5)"
 success_criteria:
   - id: S1
     criterion: A valid assignment envelope produces a structured AgentInvokeResponse with outcome classification and execution summary
     traces:
-      - prd001-tool-system-components-interfaces AC1
+      - srd001-tool-system-components-interfaces AC1
   - id: S2
     criterion: An invalid assignment envelope or invalid Machine is rejected before the Engine dispatch loop starts
     traces:
-      - prd001-tool-system-components-interfaces AC1
+      - srd001-tool-system-components-interfaces AC1
   - id: S3
     criterion: The runtime performs no git operations; branch management belongs to the orchestrator
     traces:
-      - prd001-tool-system-components-interfaces AC1
+      - srd001-tool-system-components-interfaces AC1
 test_suite: test-rel01.0

--- a/docs/specs/use-cases/rel01.1-uc003-hexagonal-runtime-wiring.yaml
+++ b/docs/specs/use-cases/rel01.1-uc003-hexagonal-runtime-wiring.yaml
@@ -12,15 +12,15 @@ flow:
   - F4: "Execute a dispatch cycle through the wired ports to validate end-to-end data flow"
   - F5: "Replace one adapter with a test double and verify Engine behavior is unchanged"
 touchpoints:
-  - T1: "Engine — depends on ports only (prd009-hexagonal-ports-and-wiring R1, R2)"
-  - T2: "Port interfaces — LLMInvocationPort, WorkspaceDiscoveryReadPort, WorkspaceMutationPort, ValidationPort, StateAuditPorts, TracePort (prd009-hexagonal-ports-and-wiring R3)"
+  - T1: "Engine — depends on ports only (srd009-hexagonal-ports-and-wiring R1, R2)"
+  - T2: "Port interfaces — LLMInvocationPort, WorkspaceDiscoveryReadPort, WorkspaceMutationPort, ValidationPort, StateAuditPorts, TracePort (srd009-hexagonal-ports-and-wiring R3)"
 success_criteria:
   - id: S1
     criterion: Core domain services compile and run with port interfaces only, no adapter imports
     traces:
-      - prd009-hexagonal-ports-and-wiring AC1
+      - srd009-hexagonal-ports-and-wiring AC1
   - id: S2
     criterion: Replacing an adapter with a test double does not require core code changes
     traces:
-      - prd009-hexagonal-ports-and-wiring AC2
+      - srd009-hexagonal-ports-and-wiring AC2
 test_suite: test-rel01.1

--- a/docs/specs/use-cases/rel01.3-uc004-comparative-conformance-evaluation.yaml
+++ b/docs/specs/use-cases/rel01.3-uc004-comparative-conformance-evaluation.yaml
@@ -7,7 +7,7 @@ summary: |
 actor: Developer or evaluator running conformance checks
 trigger: Runtime reaches sufficient maturity for baseline comparison
 flow:
-  - F1: "Load conformance baseline requirements from prd021"
+  - F1: "Load conformance baseline requirements from srd021"
   - F2: "Configure test harness with runtime instance and baseline checklist"
   - F3: "Execute prompt transparency checks: verify prompt assembly is inspectable and reproducible"
   - F4: "Execute parser robustness checks: verify tool call normalization handles malformed inputs"
@@ -15,22 +15,22 @@ flow:
   - F6: "Execute tool architecture checks: verify dynamic tool subset computation per request"
   - F7: "Execute Go creation readiness checks: verify Go-specific diagnostics and LSP integration"
   - F8: "Aggregate results and produce conformance report"
-  - F9: "Identify gaps and map to PRD requirements for future work"
+  - F9: "Identify gaps and map to SRD requirements for future work"
 touchpoints:
-  - T1: "StitchBoundaryAdapter — entry interface conformance (prd021-comparative-agent-conformance-baseline R1)"
-  - T2: "Engine — workflow control conformance (prd021-comparative-agent-conformance-baseline R2)"
-  - T3: "ToolContractValidator — parser robustness conformance (prd021-comparative-agent-conformance-baseline R3)"
-  - T4: "PermissionExecutor — safety and permission conformance (prd021-comparative-agent-conformance-baseline R4)"
-  - T5: "Machine — output routing conformance via signal-based transitions (prd021-comparative-agent-conformance-baseline R5)"
-  - T6: "ValidationPort — Go diagnostics conformance (prd021-comparative-agent-conformance-baseline R6)"
-  - T7: "CrumbLedger — audit quality conformance (prd021-comparative-agent-conformance-baseline R7)"
+  - T1: "StitchBoundaryAdapter — entry interface conformance (srd021-comparative-agent-conformance-baseline R1)"
+  - T2: "Engine — workflow control conformance (srd021-comparative-agent-conformance-baseline R2)"
+  - T3: "ToolContractValidator — parser robustness conformance (srd021-comparative-agent-conformance-baseline R3)"
+  - T4: "PermissionExecutor — safety and permission conformance (srd021-comparative-agent-conformance-baseline R4)"
+  - T5: "Machine — output routing conformance via signal-based transitions (srd021-comparative-agent-conformance-baseline R5)"
+  - T6: "ValidationPort — Go diagnostics conformance (srd021-comparative-agent-conformance-baseline R6)"
+  - T7: "CrumbLedger — audit quality conformance (srd021-comparative-agent-conformance-baseline R7)"
 success_criteria:
   - id: S1
     criterion: Conformance report covers all baseline dimensions with pass/fail/partial results
     traces:
-      - prd021-comparative-agent-conformance-baseline AC1
+      - srd021-comparative-agent-conformance-baseline AC1
   - id: S2
-    criterion: Identified gaps are mapped to specific PRD R-items for follow-up
+    criterion: Identified gaps are mapped to specific SRD R-items for follow-up
     traces:
-      - prd021-comparative-agent-conformance-baseline AC2
+      - srd021-comparative-agent-conformance-baseline AC2
 test_suite: test-rel01.3

--- a/magefiles/go.mod
+++ b/magefiles/go.mod
@@ -4,7 +4,7 @@ go 1.26.4
 
 require (
 	github.com/magefile/mage v1.17.2
-	github.com/mesh-intelligence/cobbler-scaffold v0.20260308.5
+	github.com/mesh-intelligence/cobbler-scaffold v0.20260612.1
 )
 
 require (

--- a/magefiles/go.sum
+++ b/magefiles/go.sum
@@ -1,7 +1,7 @@
 github.com/magefile/mage v1.17.2 h1:fyXVu1eadI8Ap1HCCNgEhJ5McIWiYhLR8uol64ZZc40=
 github.com/magefile/mage v1.17.2/go.mod h1:Yj51kqllmsgFpvvSzgrZPK9WtluG3kUhFaBUVLo4feA=
-github.com/mesh-intelligence/cobbler-scaffold v0.20260308.5 h1:BIF8emTDbuHurxHrKOx5lBwrcvtlfsg1DjD4yf5RqXk=
-github.com/mesh-intelligence/cobbler-scaffold v0.20260308.5/go.mod h1:7ClERKqRLakydq2mwtElXc/uuNoiHD9SnKxndu8w5yg=
+github.com/mesh-intelligence/cobbler-scaffold v0.20260612.1 h1:ByAcl1pcwvPOhf35He34s5sUNuifXGavFguIAAfxm48=
+github.com/mesh-intelligence/cobbler-scaffold v0.20260612.1/go.mod h1:7ClERKqRLakydq2mwtElXc/uuNoiHD9SnKxndu8w5yg=
 github.com/schlunsen/claude-agent-sdk-go v0.5.1 h1:8hho5wd5XU87q91ssEFeJmgS0whm6JTroqtwnaUQxcA=
 github.com/schlunsen/claude-agent-sdk-go v0.5.1/go.mod h1:bH59LsKvDqUtYzW+6MNoaFEjcpMtfdvRNjQDCyfBJ+o=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=

--- a/magefiles/orchestrator.go
+++ b/magefiles/orchestrator.go
@@ -64,88 +64,85 @@ func logf(format string, args ...any) {
 // --- Top-level targets ---
 
 // Init initializes the project.
-func Init() error { return newOrch().Init() }
+func Init() error { return newOrch().Generator.Init() }
 
 // Reset performs a full reset: cobbler and generator.
-func Reset() error { return newOrch().FullReset() }
+func Reset() error { return newOrch().Generator.FullReset() }
 
 // Build compiles the project binary.
-func Build() error { return newOrch().Build() }
+func Build() error { return newOrch().Builder.Build() }
 
 // Lint runs golangci-lint on the project.
-func Lint() error { return newOrch().Lint() }
+func Lint() error { return newOrch().Builder.Lint() }
 
 // Install runs go install for the main package.
-func Install() error { return newOrch().Install() }
+func Install() error { return newOrch().Builder.Install() }
 
 // Clean removes build artifacts.
-func Clean() error { return newOrch().Clean() }
+func Clean() error { return newOrch().Builder.Clean() }
 
-// Credentials extracts Claude credentials from the macOS Keychain.
-func Credentials() error { return newOrch().ExtractCredentials() }
-
-// Analyze performs cross-artifact consistency checks (PRDs, use cases, test suites, roadmap).
-func Analyze() error { return newOrch().Analyze() }
+// Analyze performs cross-artifact consistency checks (SRDs, use cases, test suites, roadmap).
+func Analyze() error { return newOrch().Analyzer.Analyze() }
 
 // Tag creates a documentation release tag (v0.YYYYMMDD.N) and builds the container image.
-func Tag() error { return newOrch().Tag() }
+func Tag() error { return newOrch().Releaser.Tag() }
 
 // --- Scaffold targets ---
 
 // Pop removes orchestrator-managed files from the target repository:
 // magefiles/orchestrator.go, docs/constitutions/, docs/prompts/, and
 // configuration.yaml. Pass "." for the current directory.
-func (Scaffold) Pop(target string) error { return newOrch().Uninstall(target) }
+func (Scaffold) Pop(target string) error { return newOrch().Scaffolder.Uninstall(target) }
 
 // --- Cobbler targets ---
 
 // Measure assesses project state and proposes new tasks via Claude.
-func (Cobbler) Measure() error { return newOrch().Measure() }
+func (Cobbler) Measure() error { return newOrch().Measure.Measure() }
 
 // Stitch picks ready tasks and invokes Claude to execute them.
-func (Cobbler) Stitch() error { return newOrch().Stitch() }
+func (Cobbler) Stitch() error { return newOrch().Stitch.Stitch() }
 
 // Reset removes the cobbler scratch directory.
-func (Cobbler) Reset() error { return newOrch().CobblerReset() }
+func (Cobbler) Reset() error { return newOrch().ClaudeRunner.CobblerReset() }
 
 // --- Generator targets ---
 
 // Start begins a new generation trail.
-func (Generator) Start() error { return newOrch().GeneratorStart() }
+func (Generator) Start() error { return newOrch().Generator.GeneratorStart() }
 
 // Run executes measure + stitch cycles using the generation.cycles value in configuration.yaml.
 // Use RunN to override the cycle count for a single invocation.
-func (Generator) Run() error { return newOrch().GeneratorRun(0) }
+func (Generator) Run() error { return newOrch().Generator.GeneratorRun(0) }
 
 // RunN executes exactly n cycles of measure + stitch within the current generation.
 // Pass n > 0 to override generation.cycles in configuration.yaml for this run only.
-func (Generator) RunN(n int) error { return newOrch().GeneratorRun(n) }
+func (Generator) RunN(n int) error { return newOrch().Generator.GeneratorRun(n) }
 
 // Resume recovers from an interrupted run and continues.
-func (Generator) Resume() error { return newOrch().GeneratorResume() }
+func (Generator) Resume() error { return newOrch().Generator.GeneratorResume() }
 
 // Stop completes a generation trail and merges it into main.
-func (Generator) Stop() error { return newOrch().GeneratorStop() }
+func (Generator) Stop() error { return newOrch().Generator.GeneratorStop() }
 
 // List shows active branches and past generations.
-func (Generator) List() error { return newOrch().GeneratorList() }
+func (Generator) List() error { return newOrch().Generator.GeneratorList() }
 
 // Switch commits current work and checks out another generation branch.
-func (Generator) Switch() error { return newOrch().GeneratorSwitch() }
+func (Generator) Switch() error { return newOrch().Generator.GeneratorSwitch() }
 
 // Reset destroys generation branches, worktrees, and Go source directories.
-func (Generator) Reset() error { return newOrch().GeneratorReset() }
+func (Generator) Reset() error { return newOrch().Generator.GeneratorReset() }
 
 // --- Stats targets ---
 
 // Loc prints Go lines of code and documentation word counts.
-func (Stats) Loc() error { return newOrch().Stats() }
+func (Stats) Loc() error { return newOrch().Stats.PrintStats() }
 
 // Tokens enumerates prompt-attached files and counts tokens via the Anthropic API.
 func (Stats) Tokens() error { return newOrch().TokenStats() }
 
 // Generator prints a status report for the current generation run.
-func (Stats) Generator() error { return newOrch().GeneratorStats() }
+func (Stats) Generator() error { return newOrch().Stats.GeneratorStats() }
 
 // --- Prompt targets ---
 


### PR DESCRIPTION
## Summary

Renamed all PRD (Product Requirements Document) references to SRD (Software Requirements Document) across the entire codebase. Moved the directory, renamed 28 files, updated all cross-references, and upgraded magefiles to cobbler-scaffold v0.20260612.1 for SRD naming support.

## Changes

- Moved `docs/specs/product-requirements/` to `docs/specs/software-requirements/`
- Renamed 28 files from `prdNNN-*.yaml` to `srdNNN-*.yaml`
- Updated all `id:` fields from `prd` to `srd` prefix
- Updated all cross-references in 65 files (ARCHITECTURE, VISION, SPECIFICATIONS, component-catalog, use cases, test suites, interface specs, README, configuration, prompt library)
- Renamed `legacy-prd-reconciliation.yaml` to `legacy-srd-reconciliation.yaml`
- Updated SPECIFICATIONS.yaml: `prd_index` → `srd_index`, `prd_to_use_case_mapping` → `srd_to_use_case_mapping`
- Upgraded magefiles to cobbler-scaffold v0.20260612.1
- Synced constitutions from latest scaffold (added interface.yaml, issue-format.yaml, semantic-model.yaml)

## Stats

- 28 SRDs, 4 use cases, 3 test suites, 10 interface specs, 5 releases
- mage analyze: 39 standard files, 28 SRDs found (was 0), 0 broken citations
- 11 pre-existing schema errors (semantic_model false positives)
- spec_words: srd=13230, test_suite=169, use_case=1166

## Test plan

- [x] mage analyze finds 28 SRDs
- [x] No PRD references remain in any documentation or code
- [x] All SRD references resolve (0 broken citations, 0 broken struct_refs)
- [x] No new schema validation errors

Closes #3